### PR TITLE
feat: Support user-defined output

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,11 +2,11 @@ version: v1
 managed:
   enabled: false
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/csharp:v21.1.0-1
+  - remote: buf.build/protocolbuffers/csharp:v23.1
     opt:
       - base_namespace=
       - file_extension=.g.cs
     out: ./src/Sdk
 
-  - remote: buf.build/grpc/plugins/csharp:v1.46.3-1
+  - remote: buf.build/grpc/csharp:v1.55.0
     out: ./src/Sdk

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,11 +2,11 @@ version: v1
 managed:
   enabled: false
 plugins:
-  - remote: buf.build/protocolbuffers/csharp:v23.1
+  - plugin: buf.build/protocolbuffers/csharp:v23.1
     opt:
       - base_namespace=
       - file_extension=.g.cs
     out: ./src/Sdk
 
-  - remote: buf.build/grpc/csharp:v1.55.0
+  - plugin: buf.build/grpc/csharp:v1.55.0
     out: ./src/Sdk

--- a/buf.lock
+++ b/buf.lock
@@ -4,16 +4,20 @@ deps:
   - remote: buf.build
     owner: cerbos
     repository: cerbos-api
-    commit: 59b3e105ab894f25a7df34a1b3827676
+    commit: e1f056cc04374bbc9e0e5049b844a0c2
+    digest: shake256:05af02915c1e3c3a543a8df7395c726325fcb090ffc76c99f29ab5cf031df320b21a344018ab096b701810a38ad7fa935f307f48389b21015311822f17aed2f9
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
-    commit: 45685e052c7e406b9fbd441fc7a568a5
+    commit: 6607b10f00ed4a3d98f906807131c44a
+    digest: shake256:acc7b2ededb2f88d296862943a003b157bdb68ec93ed13dcd8566b2d06e47993ea6daf12013b9655658aaf6bbdb141cf65bfe400ce2870f4654b0a5b45e57c09
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 62f35d8aed1149c291d606d958a7ce32
+    commit: 5ae7f88519b04fe1965da0f8a375a088
+    digest: shake256:27d9fcdc0e3eb957449dc3d17e2d24c7ce59c3c483ecf128818183c336dfd28595ecd13771fb3172247775caf7707c4076dd8e70c5ac2cbcac170df35e4d0028
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: bc28b723cd774c32b6fbc77621518765
+    commit: a1ecdc58eccd49aa8bea2a7a9022dc27
+    digest: shake256:efdd86fbdc42e8b7259fe461a49656827a03fb7cba0b3b9eb622ca10654ec6beccb9a051229c1553ccd89ed3e95d69ad4d7c799f1da3f3f1bd447b7947a4893e

--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: cerbos
     repository: cerbos-api
-    commit: e1f056cc04374bbc9e0e5049b844a0c2
-    digest: shake256:05af02915c1e3c3a543a8df7395c726325fcb090ffc76c99f29ab5cf031df320b21a344018ab096b701810a38ad7fa935f307f48389b21015311822f17aed2f9
+    commit: 9930b65ea1d14cd7abdffdc4d7591344
+    digest: shake256:92c9aa8d21618f28a085b024f589811a30d9bca2d9094388e80e4294737ad39abcae5a205dd7e00610348d20998a7c033aa02d97a85b3beba3f01260034005aa
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate

--- a/proto/cerbos/engine/v1/engine.proto
+++ b/proto/cerbos/engine/v1/engine.proto
@@ -163,6 +163,18 @@ message CheckOutput {
   map<string, ActionEffect> actions = 3;
   repeated string effective_derived_roles = 4;
   repeated cerbos.schema.v1.ValidationError validation_errors = 5;
+  repeated OutputEntry outputs = 6;
+}
+
+message OutputEntry {
+  string src = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "Rule that matched to produce this output."
+    example: "\"resource.expense.v1/acme#rule-001\""
+  }];
+  google.protobuf.Value val = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "Dynamic output, determined by user defined rule output."
+    example: "\"some_string\""
+  }];
 }
 
 message Resource {
@@ -294,6 +306,7 @@ message Trace {
       KIND_SCOPE = 11;
       KIND_VARIABLE = 12;
       KIND_VARIABLES = 13;
+      KIND_OUTPUT = 14;
     }
 
     message Variable {
@@ -312,6 +325,7 @@ message Trace {
       string rule = 8;
       string scope = 9;
       Variable variable = 10;
+      string output = 11;
     }
   }
 

--- a/proto/cerbos/policy/v1/policy.proto
+++ b/proto/cerbos/policy/v1/policy.proto
@@ -82,6 +82,7 @@ message ResourceRule {
     ]
   }];
   string name = 6 [(validate.rules).string.pattern = "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"];
+  Output output = 7;
 }
 
 message PrincipalPolicy {
@@ -105,6 +106,7 @@ message PrincipalRule {
       ]
     }];
     string name = 4 [(validate.rules).string.pattern = "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"];
+    Output output = 5;
   }
 
   string resource = 1 [(validate.rules).string = {min_len: 1}];
@@ -151,6 +153,10 @@ message Match {
     ExprList none = 3;
     string expr = 4;
   }
+}
+
+message Output {
+  string expr = 1;
 }
 
 message Schemas {

--- a/proto/cerbos/policy/v1/policy.proto
+++ b/proto/cerbos/policy/v1/policy.proto
@@ -7,6 +7,7 @@ package cerbos.policy.v1;
 
 import "cerbos/effect/v1/effect.proto";
 import "cerbos/engine/v1/engine.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
@@ -233,6 +234,11 @@ message TestTable {
     string aux_data = 4;
   }
 
+  message OutputExpectations {
+    string action = 1 [(validate.rules).string.min_len = 1];
+    repeated cerbos.engine.v1.OutputEntry expected = 2 [(validate.rules).repeated.min_items = 1];
+  }
+
   message Expectation {
     string principal = 1 [(validate.rules).string.min_len = 1];
     string resource = 2 [(validate.rules).string.min_len = 1];
@@ -242,6 +248,7 @@ message TestTable {
         string: {min_len: 1}
       }
     }];
+    repeated OutputExpectations outputs = 4;
   }
 
   string name = 1 [(validate.rules).string.min_len = 1];
@@ -260,6 +267,10 @@ message Test {
     string resource_key = 3 [(validate.rules).string.min_len = 1];
   }
 
+  message OutputEntries {
+    map<string, google.protobuf.Value> entries = 1;
+  }
+
   TestName name = 1 [(validate.rules).message.required = true];
   string description = 2;
   bool skip = 3;
@@ -272,6 +283,7 @@ message Test {
     }
   }];
   TestOptions options = 7;
+  map<string, OutputEntries> expected_outputs = 8;
 }
 
 message TestResults {
@@ -333,9 +345,27 @@ message TestResults {
     repeated cerbos.engine.v1.Trace engine_trace = 4;
   }
 
+  message OutputFailure {
+    message MismatchedValue {
+      google.protobuf.Value expected = 1;
+      google.protobuf.Value actual = 2;
+    }
+
+    message MissingValue {
+      google.protobuf.Value expected = 1;
+    }
+
+    string src = 1;
+    oneof outcome {
+      MismatchedValue mismatched = 2;
+      MissingValue missing = 3;
+    }
+  }
+
   message Failure {
     cerbos.effect.v1.Effect expected = 1;
     cerbos.effect.v1.Effect actual = 2;
+    repeated OutputFailure outputs = 3;
   }
 
   repeated Suite suites = 1;

--- a/proto/cerbos/request/v1/request.proto
+++ b/proto/cerbos/request/v1/request.proto
@@ -521,6 +521,18 @@ message ListPoliciesRequest {
     (google.api.field_behavior) = OPTIONAL,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Include disabled policies"}
   ];
+  string name_regexp = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Filter policies by name with regexp"}
+  ];
+  string scope_regexp = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Filter policies by scope with regexp"}
+  ];
+  string version_regexp = 4 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Filter policies by version with regexp"}
+  ];
 }
 
 message GetPolicyRequest {

--- a/proto/cerbos/response/v1/response.proto
+++ b/proto/cerbos/response/v1/response.proto
@@ -219,6 +219,10 @@ message CheckResourcesResponse {
       description: "Metadata about policy evaluation"
       example: "{\"actions\": {\"view:*\":{\"matched_policy\": \"album:object:default\"},\"comment\":{\"matched_policy\": \"album:object:default\"}}, \"effective_derived_roles\": [\"owner\"]}"
     }];
+    repeated cerbos.engine.v1.OutputEntry outputs = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Output for each rule with outputs configured"
+      example: "[{\"src\": \"resource.expense.v1/acme#rule-001\", \"val\": \"view_allowed:alice\"}, {\"src\": \"resource.expense.v1/acme#rule-002\", \"val\": \"foo\"}]"
+    }];
   }
 
   string request_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {

--- a/proto/cerbos/response/v1/response.proto
+++ b/proto/cerbos/response/v1/response.proto
@@ -286,12 +286,15 @@ message PlaygroundEvaluateResponse {
     string action = 1;
     cerbos.effect.v1.Effect effect = 2;
     string policy = 3;
-    repeated string effective_derived_roles = 4;
-    repeated cerbos.schema.v1.ValidationError validation_errors = 5;
+    repeated string effective_derived_roles = 4 [deprecated = true];
+    repeated cerbos.schema.v1.ValidationError validation_errors = 5 [deprecated = true];
   }
 
   message EvalResultList {
     repeated EvalResult results = 1;
+    repeated string effective_derived_roles = 2;
+    repeated cerbos.schema.v1.ValidationError validation_errors = 3;
+    repeated cerbos.engine.v1.OutputEntry outputs = 4;
   }
 
   string playground_id = 1;

--- a/proto/cerbos/telemetry/v1/telemetry.proto
+++ b/proto/cerbos/telemetry/v1/telemetry.proto
@@ -57,11 +57,18 @@ message ServerLaunch {
         google.protobuf.Duration poll_interval = 2;
       }
 
+      message Bundle {
+        string pdp_id = 1;
+        string bundle_source = 2;
+        string client_id = 3;
+      }
+
       string driver = 1;
       oneof store {
         Disk disk = 2;
         Git git = 3;
         Blob blob = 4;
+        Bundle bundle = 5;
       }
     }
 

--- a/proto/google/api/expr/v1alpha1/checked.proto
+++ b/proto/google/api/expr/v1alpha1/checked.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -243,8 +243,8 @@ message Decl {
   // logging which are not observable from CEL).
   message FunctionDecl {
     // An overload indicates a function's parameter types and return type, and
-    // may optionally include a function body described in terms of [Expr][google.api.expr.v1alpha1.Expr]
-    // values.
+    // may optionally include a function body described in terms of
+    // [Expr][google.api.expr.v1alpha1.Expr] values.
     //
     // Functions overloads are declared in either a function or method
     // call-style. For methods, the `params[0]` is the expected type of the
@@ -256,11 +256,13 @@ message Decl {
       // Required. Globally unique overload name of the function which reflects
       // the function name and argument types.
       //
-      // This will be used by a [Reference][google.api.expr.v1alpha1.Reference] to indicate the `overload_id` that
-      // was resolved for the function `name`.
+      // This will be used by a [Reference][google.api.expr.v1alpha1.Reference]
+      // to indicate the `overload_id` that was resolved for the function
+      // `name`.
       string overload_id = 1;
 
-      // List of function parameter [Type][google.api.expr.v1alpha1.Type] values.
+      // List of function parameter [Type][google.api.expr.v1alpha1.Type]
+      // values.
       //
       // Param types are disjoint after generic type parameters have been
       // replaced with the type `DYN`. Since the `DYN` type is compatible with
@@ -302,9 +304,11 @@ message Decl {
   // Declarations are organized in containers and this represents the full path
   // to the declaration in its container, as in `google.api.expr.Decl`.
   //
-  // Declarations used as [FunctionDecl.Overload][google.api.expr.v1alpha1.Decl.FunctionDecl.Overload] parameters may or may not
-  // have a name depending on whether the overload is function declaration or a
-  // function definition containing a result [Expr][google.api.expr.v1alpha1.Expr].
+  // Declarations used as
+  // [FunctionDecl.Overload][google.api.expr.v1alpha1.Decl.FunctionDecl.Overload]
+  // parameters may or may not have a name depending on whether the overload is
+  // function declaration or a function definition containing a result
+  // [Expr][google.api.expr.v1alpha1.Expr].
   string name = 1;
 
   // Required. The declaration kind.
@@ -329,7 +333,8 @@ message Reference {
   // presented candidates must happen at runtime because of dynamic types. The
   // type checker attempts to narrow down this list as much as possible.
   //
-  // Empty if this is not a reference to a [Decl.FunctionDecl][google.api.expr.v1alpha1.Decl.FunctionDecl].
+  // Empty if this is not a reference to a
+  // [Decl.FunctionDecl][google.api.expr.v1alpha1.Decl.FunctionDecl].
   repeated string overload_id = 3;
 
   // For references to constants, this may contain the value of the

--- a/proto/google/api/expr/v1alpha1/syntax.proto
+++ b/proto/google/api/expr/v1alpha1/syntax.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,6 +104,14 @@ message Expr {
   message CreateList {
     // The elements part of the list.
     repeated Expr elements = 1;
+
+    // The indices within the elements list which are marked as optional
+    // elements.
+    //
+    // When an optional-typed value is present, the value it contains
+    // is included in the list. If the optional-typed value is absent, the list
+    // element is omitted from the CreateList result.
+    repeated int32 optional_indices = 2;
   }
 
   // A map or message creation expression.
@@ -129,7 +137,14 @@ message Expr {
       }
 
       // Required. The value assigned to the key.
+      //
+      // If the optional_entry field is true, the expression must resolve to an
+      // optional-typed value. If the optional value is present, the key will be
+      // set; however, if the optional value is absent, the key will be unset.
       Expr value = 4;
+
+      // Whether the key-value pair is optional.
+      bool optional_entry = 5;
     }
 
     // The type name of the message to be created, empty when creating map

--- a/proto/google/api/field_behavior.proto
+++ b/proto/google/api/field_behavior.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/google/api/http.proto
+++ b/proto/google/api/http.proto
@@ -1,4 +1,4 @@
-// Copyright 2015 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -210,15 +210,18 @@ message Http {
 // 1. Leaf request fields (recursive expansion nested messages in the request
 //    message) are classified into three categories:
 //    - Fields referred by the path template. They are passed via the URL path.
-//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+//    are passed via the HTTP
 //      request body.
 //    - All other fields are passed via the URL query parameters, and the
 //      parameter name is the field path in the request message. A repeated
 //      field can be represented as multiple query parameters under the same
 //      name.
-//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+//  query parameter, all fields
 //     are passed via URL path and HTTP request body.
-//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+//  request body, all
 //     fields are passed via URL path and URL query parameters.
 //
 // ### Path template syntax
@@ -313,7 +316,8 @@ message Http {
 message HttpRule {
   // Selects a method to which this rule applies.
   //
-  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax
+  // details.
   string selector = 1;
 
   // Determines the URL pattern is matched by this rules. This pattern can be

--- a/proto/google/api/visibility.proto
+++ b/proto/google/api/visibility.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,16 +55,17 @@ extend google.protobuf.ServiceOptions {
   google.api.VisibilityRule api_visibility = 72295727;
 }
 
-// `Visibility` defines restrictions for the visibility of service
-// elements.  Restrictions are specified using visibility labels
-// (e.g., PREVIEW) that are elsewhere linked to users and projects.
+// `Visibility` restricts service consumer's access to service elements,
+// such as whether an application can call a visibility-restricted method.
+// The restriction is expressed by applying visibility labels on service
+// elements. The visibility labels are elsewhere linked to service consumers.
 //
-// Users and projects can have access to more than one visibility label. The
-// effective visibility for multiple labels is the union of each label's
-// elements, plus any unrestricted elements.
+// A service can define multiple visibility labels, but a service consumer
+// should be granted at most one visibility label. Multiple visibility
+// labels for a single service consumer are not supported.
 //
-// If an element and its parents have no restrictions, visibility is
-// unconditionally granted.
+// If an element and all its parents have no visibility label, its visibility
+// is unconditionally granted.
 //
 // Example:
 //
@@ -89,7 +90,8 @@ message Visibility {
 message VisibilityRule {
   // Selects methods, messages, fields, enums, etc. to which this rule applies.
   //
-  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax
+  // details.
   string selector = 1;
 
   // A comma-separated list of visibility labels that apply to the `selector`.

--- a/proto/protoc-gen-openapiv2/options/openapiv2.proto
+++ b/proto/protoc-gen-openapiv2/options/openapiv2.proto
@@ -34,7 +34,7 @@ enum Scheme {
 //      };
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
 //      };
 //    };
 //    schemes: HTTPS;
@@ -92,12 +92,14 @@ message Swagger {
   // (that is, there is a logical OR between the security requirements).
   // Individual operations can override this definition.
   repeated SecurityRequirement security = 12;
-  // field 13 is reserved for 'tags', which are supposed to be exposed as and
-  // customizable as proto services. TODO(ivucica): add processing of proto
-  // service objects into OpenAPI v2 Tag objects.
-  reserved 13;
+  // A list of tags for API documentation control. Tags can be used for logical
+  // grouping of operations by resources or any other qualifier.
+  repeated Tag tags = 13;
   // Additional external documentation.
   ExternalDocumentation external_docs = 14;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 15;
 }
 
@@ -169,7 +171,55 @@ message Operation {
   // definition overrides any declared top-level security. To remove a top-level
   // security declaration, an empty array can be used.
   repeated SecurityRequirement security = 12;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 13;
+  // Custom parameters such as HTTP request headers.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/
+  // and https://swagger.io/specification/v2/#parameter-object.
+  Parameters parameters = 14;
+}
+
+// `Parameters` is a representation of OpenAPI v2 specification's parameters object.
+// Note: This technically breaks compatibility with the OpenAPI 2 definition structure as we only
+// allow header parameters to be set here since we do not want users specifying custom non-header
+// parameters beyond those inferred from the Protobuf schema.
+// See: https://swagger.io/specification/v2/#parameter-object
+message Parameters {
+  // `Headers` is one or more HTTP header parameter.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/#header-parameters
+  repeated HeaderParameter headers = 1;
+}
+
+// `HeaderParameter` a HTTP header parameter.
+// See: https://swagger.io/specification/v2/#parameter-object
+message HeaderParameter {
+  // `Type` is a a supported HTTP header type.
+  // See https://swagger.io/specification/v2/#parameterType.
+  enum Type {
+    UNKNOWN = 0;
+    STRING = 1;
+    NUMBER = 2;
+    INTEGER = 3;
+    BOOLEAN = 4;
+  }
+
+  // `Name` is the header name.
+  string name = 1;
+  // `Description` is a short description of the header.
+  string description = 2;
+  // `Type` is the type of the object. The value MUST be one of "string", "number", "integer", or "boolean". The "array" type is not supported.
+  // See: https://swagger.io/specification/v2/#parameterType.
+  Type type = 3;
+  // `Format` The extending format for the previously mentioned type.
+  string format = 4;
+  // `Required` indicates if the header is optional
+  bool required = 5;
+  // field 6 is reserved for 'items', but in OpenAPI-specific way.
+  reserved 6;
+  // field 7 is reserved `Collection Format`. Determines the format of the array if type array is used.
+  reserved 7;
 }
 
 // `Header` is a representation of OpenAPI v2 specification's Header object.
@@ -235,6 +285,9 @@ message Response {
   // `Examples` gives per-mimetype response examples.
   // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#example-object
   map<string, string> examples = 4;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 5;
 }
 
@@ -256,7 +309,7 @@ message Response {
 //      };
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
 //      };
 //    };
 //    ...
@@ -277,6 +330,9 @@ message Info {
   // Provides the version of the application API (not to be confused
   // with the specification version).
   string version = 6;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 7;
 }
 
@@ -321,7 +377,7 @@ message Contact {
 //      ...
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
 //      };
 //      ...
 //    };
@@ -518,6 +574,9 @@ message JSONSchema {
     // for overlapping paths.
     string path_param_name = 47;
   }
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 48;
 }
 
@@ -526,20 +585,19 @@ message JSONSchema {
 // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#tagObject
 //
 message Tag {
-  // field 1 is reserved for 'name'. In our generator, this is (to be) extracted
-  // from the name of proto service, and thus not exposed to the user, as
-  // changing tag object's name would break the link to the references to the
-  // tag in individual operation specifications.
-  //
-  // TODO(ivucica): Add 'name' property. Use it to allow override of the name of
+  // The name of the tag. Use it to allow override of the name of a
   // global Tag object, then use that name to reference the tag throughout the
   // OpenAPI file.
-  reserved 1;
+  string name = 1;
   // A short description for the tag. GFM syntax can be used for rich text
   // representation.
   string description = 2;
   // Additional external documentation for this tag.
   ExternalDocumentation external_docs = 3;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 4;
 }
 
 // `SecurityDefinitions` is a representation of OpenAPI v2 specification's
@@ -619,6 +677,9 @@ message SecurityScheme {
   // The available scopes for the OAuth2 security scheme.
   // Valid for oauth2.
   Scopes scopes = 8;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 9;
 }
 

--- a/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosBlockingClientTest.cs
+++ b/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosBlockingClientTest.cs
@@ -87,8 +87,8 @@ namespace Cerbos.Sdk.UnitTests
 
             Assert.That(have.Meta.Actions["approve"].MatchedPolicy, Is.EqualTo("resource.leave_request.v20210210"));
             
-            Assert.That(have.Outputs[0].Src, Is.EqualTo("resource.leave_request.v20210210#rule-007"));
-            Assert.That(have.Outputs[0].Val.StringValue, Is.EqualTo("approve:john"));
+            Assert.That(have.Outputs[0].Src, Is.EqualTo("resource.leave_request.v20210210#public-view"));
+            Assert.That(have.Outputs[0].Val.StringValue, Is.EqualTo("view:public:john"));
             
             Assert.That(have.Resource.Id, Is.EqualTo("XX125"));
             Assert.That(have.Resource.Kind, Is.EqualTo("leave_request"));

--- a/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosBlockingClientTest.cs
+++ b/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosBlockingClientTest.cs
@@ -17,7 +17,7 @@ namespace Cerbos.Sdk.UnitTests
         private const int HttpPort = 3592;
         private const int GrpcPort = 3593;
         private const string Image = "ghcr.io/cerbos/cerbos";
-        private const string Tag = "latest";
+        private const string Tag = "dev";
         private const string PathToPolicies = "./../../../res/policies";
         private const string PathToConfig = "./../../../res/config";
         private IContainer Container;
@@ -44,7 +44,7 @@ namespace Cerbos.Sdk.UnitTests
 
             Task.Run(async () => await Container.StartAsync()).Wait();
             Thread.Sleep(3000);
-            _client = new CerbosClientBuilder("http://127.0.0.1:3593").WithPlaintext().BuildBlockingClient();
+            _client = new CerbosClientBuilder("http://127.0.0.1:3593").WithPlaintext().BuildBlockingClient().WithMeta(true);
             _clientPlayground = new CerbosClientBuilder(PlaygroundHost).WithPlaygroundInstance(PlaygroundInstanceId).BuildBlockingClient();
         }
 
@@ -80,6 +80,20 @@ namespace Cerbos.Sdk.UnitTests
             
             Assert.That(have.IsAllowed("view:public"), Is.True);
             Assert.That(have.IsAllowed("approve"), Is.False);
+            
+            Assert.That(have.Meta, Is.Not.Null);
+            Assert.That(have.Outputs, Is.Not.Null);
+            Assert.That(have.Resource, Is.Not.Null);
+
+            Assert.That(have.Meta.Actions["approve"].MatchedPolicy, Is.EqualTo("resource.leave_request.v20210210"));
+            
+            Assert.That(have.Outputs[0].Src, Is.EqualTo("resource.leave_request.v20210210#rule-007"));
+            Assert.That(have.Outputs[0].Val.StringValue, Is.EqualTo("approve:john"));
+            
+            Assert.That(have.Resource.Id, Is.EqualTo("XX125"));
+            Assert.That(have.Resource.Kind, Is.EqualTo("leave_request"));
+            Assert.That(have.Resource.Scope, Is.EqualTo(""));
+            Assert.That(have.Resource.PolicyVersion, Is.EqualTo("20210210"));
         }
         
         [Test]

--- a/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosBlockingClientTest.cs
+++ b/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosBlockingClientTest.cs
@@ -87,8 +87,8 @@ namespace Cerbos.Sdk.UnitTests
 
             Assert.That(have.Meta.Actions["approve"].MatchedPolicy, Is.EqualTo("resource.leave_request.v20210210"));
             
-            Assert.That(have.Outputs[0].Src, Is.EqualTo("resource.leave_request.v20210210#public-view"));
-            Assert.That(have.Outputs[0].Val.StringValue, Is.EqualTo("view:public:john"));
+            Assert.That(have.Outputs.Get("resource.leave_request.v20210210#public-view"), Is.Not.Null);
+            Assert.That(have.Outputs.Get("resource.leave_request.v20210210#public-view").StringValue, Is.EqualTo("view:public:john"));
             
             Assert.That(have.Resource.Id, Is.EqualTo("XX125"));
             Assert.That(have.Resource.Kind, Is.EqualTo("leave_request"));

--- a/src/Sdk.UnitTests/res/policies/resource_policies/policy_01.yaml
+++ b/src/Sdk.UnitTests/res/policies/resource_policies/policy_01.yaml
@@ -57,6 +57,9 @@ resourcePolicy:
           expr: request.resource.attr.status == V.pending_approval
       derivedRoles:
         - direct_manager
+      output:
+        expr: |-
+          "approve:%s".format([request.principal.id])
       effect: EFFECT_ALLOW
 
     - actions: ["delete"]

--- a/src/Sdk.UnitTests/res/policies/resource_policies/policy_01.yaml
+++ b/src/Sdk.UnitTests/res/policies/resource_policies/policy_01.yaml
@@ -49,6 +49,9 @@ resourcePolicy:
       derivedRoles:
         - any_employee
       effect: EFFECT_ALLOW
+      output:
+        expr: |-
+          "view:public:%s".format([request.principal.id])
       name: public-view
 
     - actions: ["approve"]
@@ -57,9 +60,6 @@ resourcePolicy:
           expr: request.resource.attr.status == V.pending_approval
       derivedRoles:
         - direct_manager
-      output:
-        expr: |-
-          "approve:%s".format([request.principal.id])
       effect: EFFECT_ALLOW
 
     - actions: ["delete"]

--- a/src/Sdk/Cerbos/Api/V1/Audit/Audit.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Audit/Audit.g.cs
@@ -355,7 +355,7 @@ namespace Cerbos.Api.V1.Audit {
         }
         Peer.MergeFrom(other.Peer);
       }
-      metadata_.Add(other.metadata_);
+      metadata_.MergeFrom(other.metadata_);
       if (other.Method.Length != 0) {
         Method = other.Method;
       }
@@ -840,7 +840,7 @@ namespace Cerbos.Api.V1.Audit {
       if (other.Error.Length != 0) {
         Error = other.Error;
       }
-      metadata_.Add(other.metadata_);
+      metadata_.MergeFrom(other.metadata_);
       switch (other.MethodCase) {
         case MethodOneofCase.CheckResources:
           if (CheckResources == null) {

--- a/src/Sdk/Cerbos/Api/V1/Engine/Engine.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Engine/Engine.g.cs
@@ -102,99 +102,107 @@ namespace Cerbos.Api.V1.Engine {
             "aXBhbBgDIAEoCzIbLmNlcmJvcy5lbmdpbmUudjEuUHJpbmNpcGFsQgvgQQL6",
             "QgWKAQIQAVIJcHJpbmNpcGFsEisKB2FjdGlvbnMYBCADKAlCEeBBAvpCC5IB",
             "CBgBIgRyAhABUgdhY3Rpb25zEjQKCGF1eF9kYXRhGAUgASgLMhkuY2VyYm9z",
-            "LmVuZ2luZS52MS5BdXhEYXRhUgdhdXhEYXRhIvMDCgtDaGVja091dHB1dBId",
+            "LmVuZ2luZS52MS5BdXhEYXRhUgdhdXhEYXRhIqwECgtDaGVja091dHB1dBId",
             "CgpyZXF1ZXN0X2lkGAEgASgJUglyZXF1ZXN0SWQSHwoLcmVzb3VyY2VfaWQY",
             "AiABKAlSCnJlc291cmNlSWQSRAoHYWN0aW9ucxgDIAMoCzIqLmNlcmJvcy5l",
             "bmdpbmUudjEuQ2hlY2tPdXRwdXQuQWN0aW9uc0VudHJ5UgdhY3Rpb25zEjYK",
             "F2VmZmVjdGl2ZV9kZXJpdmVkX3JvbGVzGAQgAygJUhVlZmZlY3RpdmVEZXJp",
             "dmVkUm9sZXMSTgoRdmFsaWRhdGlvbl9lcnJvcnMYBSADKAsyIS5jZXJib3Mu",
-            "c2NoZW1hLnYxLlZhbGlkYXRpb25FcnJvclIQdmFsaWRhdGlvbkVycm9ycxpu",
-            "CgxBY3Rpb25FZmZlY3QSMAoGZWZmZWN0GAEgASgOMhguY2VyYm9zLmVmZmVj",
-            "dC52MS5FZmZlY3RSBmVmZmVjdBIWCgZwb2xpY3kYAiABKAlSBnBvbGljeRIU",
-            "CgVzY29wZRgDIAEoCVIFc2NvcGUaZgoMQWN0aW9uc0VudHJ5EhAKA2tleRgB",
-            "IAEoCVIDa2V5EkAKBXZhbHVlGAIgASgLMiouY2VyYm9zLmVuZ2luZS52MS5D",
-            "aGVja091dHB1dC5BY3Rpb25FZmZlY3RSBXZhbHVlOgI4ASLACAoIUmVzb3Vy",
-            "Y2US4QEKBGtpbmQYASABKAlCzAGSQXwyKU5hbWUgb2YgdGhlIHJlc291cmNl",
-            "IGtpbmQgYmVpbmcgYWNjZXNzZWQuSg0iYWxidW06cGhvdG8iigE/XltbOmFs",
-            "cGhhOl1dW1s6d29yZDpdXEBcLlwtXSooXDpbWzphbHBoYTpdXVtbOndvcmQ6",
-            "XVxAXC5cLV0qKSok4EEC+kJHckUQATJBXltbOmFscGhhOl1dW1s6d29yZDpd",
-            "XEBcLlwtL10qKFw6W1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwuXC0vXSopKiRS",
-            "BGtpbmQS3AEKDnBvbGljeV92ZXJzaW9uGAIgASgJQrQBkkGZATJ8VGhlIHBv",
-            "bGljeSB2ZXJzaW9uIHRvIHVzZSB0byBldmFsdWF0ZSB0aGlzIHJlcXVlc3Qu",
-            "IElmIG5vdCBzcGVjaWZpZWQsIHdpbGwgZGVmYXVsdCB0byB0aGUgc2VydmVy",
-            "LWNvbmZpZ3VyZWQgZGVmYXVsdCB2ZXJzaW9uLkoJImRlZmF1bHQiigENXltb",
-            "OndvcmQ6XV0qJOBBAfpCEXIPMg1eW1s6d29yZDpdXSokUg1wb2xpY3lWZXJz",
-            "aW9uEkMKAmlkGAMgASgJQjOSQSYyG0lEIG9mIHRoZSByZXNvdXJjZSBpbnN0",
-            "YW5jZUoHIlhYMTI1IuBBAvpCBHICEAFSAmlkEsUBCgRhdHRyGAQgAygLMiQu",
-            "Y2VyYm9zLmVuZ2luZS52MS5SZXNvdXJjZS5BdHRyRW50cnlCigGSQX8yZEth",
-            "eS12YWx1ZSBwYWlycyBvZiBjb250ZXh0dWFsIGRhdGEgYWJvdXQgdGhpcyBy",
-            "ZXNvdXJjZSB0aGF0IHNob3VsZCBiZSB1c2VkIGR1cmluZyBwb2xpY3kgZXZh",
-            "bHVhdGlvbi5KF3sib3duZXIiOiAiYnVnc19idW5ueSJ9+kIFmgECGAFSBGF0",
-            "dHISkgIKBXNjb3BlGAUgASgJQvsBkkG+ATJ9QSBkb3Qtc2VwYXJhdGVkIHNj",
-            "b3BlIHRoYXQgZGVzY3JpYmVzIHRoZSBoaWVyYXJjaHkgdGhpcyByZXNvdXJj",
-            "ZSBiZWxvbmdzIHRvLiBUaGlzIGlzIHVzZWQgZm9yIGRldGVybWluaW5nIHBv",
-            "bGljeSBpbmhlcml0YW5jZS5KCyJhY21lLmNvcnAiigEvXihbWzphbG51bTpd",
-            "XVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1cLV0qKSopKiTgQQH6QjNyMTIv",
-            "XihbWzphbG51bTpdXVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1cLV0qKSop",
-            "KiRSBXNjb3BlGk8KCUF0dHJFbnRyeRIQCgNrZXkYASABKAlSA2tleRIsCgV2",
-            "YWx1ZRgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZVIFdmFsdWU6AjgB",
-            "IuMICglQcmluY2lwYWwSQAoCaWQYASABKAlCMJJBIzITSUQgb2YgdGhlIHBy",
-            "aW5jaXBhbEoMImJ1Z3NfYnVubnki4EEC+kIEcgIQAVICaWQS3AEKDnBvbGlj",
-            "eV92ZXJzaW9uGAIgASgJQrQBkkGZATJ8VGhlIHBvbGljeSB2ZXJzaW9uIHRv",
-            "IHVzZSB0byBldmFsdWF0ZSB0aGlzIHJlcXVlc3QuIElmIG5vdCBzcGVjaWZp",
-            "ZWQsIHdpbGwgZGVmYXVsdCB0byB0aGUgc2VydmVyLWNvbmZpZ3VyZWQgZGVm",
-            "YXVsdCB2ZXJzaW9uLkoJImRlZmF1bHQiigENXltbOndvcmQ6XV0qJOBBAfpC",
-            "EXIPMg1eW1s6d29yZDpdXSokUg1wb2xpY3lWZXJzaW9uEqoBCgVyb2xlcxgD",
-            "IAMoCUKTAZJBbDJGUm9sZXMgYXNzaWduZWQgdG8gdGhpcyBwcmluY2lwYWwg",
-            "ZnJvbSB5b3VyIGlkZW50aXR5IG1hbmFnZW1lbnQgc3lzdGVtLkoIWyJ1c2Vy",
-            "Il2KARFeW1s6d29yZDpdXC1cLl0rJKgBAbABAeBBAvpCHpIBGwgBGAEiFXIT",
-            "MhFeW1s6d29yZDpdXC1cLl0rJFIFcm9sZXMSxQEKBGF0dHIYBCADKAsyJS5j",
-            "ZXJib3MuZW5naW5lLnYxLlByaW5jaXBhbC5BdHRyRW50cnlCiQGSQX4yZUtl",
-            "eS12YWx1ZSBwYWlycyBvZiBjb250ZXh0dWFsIGRhdGEgYWJvdXQgdGhpcyBw",
-            "cmluY2lwYWwgdGhhdCBzaG91bGQgYmUgdXNlZCBkdXJpbmcgcG9saWN5IGV2",
-            "YWx1YXRpb24uShV7ImJldGFfdGVzdGVyIjogdHJ1ZX36QgWaAQIYAVIEYXR0",
-            "chKTAgoFc2NvcGUYBSABKAlC/AGSQb8BMn5BIGRvdC1zZXBhcmF0ZWQgc2Nv",
-            "cGUgdGhhdCBkZXNjcmliZXMgdGhlIGhpZXJhcmNoeSB0aGlzIHByaW5jaXBh",
-            "bCBiZWxvbmdzIHRvLiBUaGlzIGlzIHVzZWQgZm9yIGRldGVybWluaW5nIHBv",
-            "bGljeSBpbmhlcml0YW5jZS5KCyJhY21lLmNvcnAiigEvXihbWzphbG51bTpd",
-            "XVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1cLV0qKSopKiTgQQH6QjNyMTIv",
-            "XihbWzphbG51bTpdXVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1cLV0qKSop",
-            "KiRSBXNjb3BlGk8KCUF0dHJFbnRyeRIQCgNrZXkYASABKAlSA2tleRIsCgV2",
-            "YWx1ZRgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZVIFdmFsdWU6AjgB",
-            "OlmSQVYKVDJSQSBwZXJzb24gb3IgYXBwbGljYXRpb24gYXR0ZW1wdGluZyB0",
-            "byBwZXJmb3JtIHRoZSBhY3Rpb25zIG9uIHRoZSBzZXQgb2YgcmVzb3VyY2Vz",
-            "LiKxAQoHQXV4RGF0YRI0CgNqd3QYASADKAsyIi5jZXJib3MuZW5naW5lLnYx",
-            "LkF1eERhdGEuSnd0RW50cnlSA2p3dBpOCghKd3RFbnRyeRIQCgNrZXkYASAB",
-            "KAlSA2tleRIsCgV2YWx1ZRgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1",
-            "ZVIFdmFsdWU6AjgBOiCSQR0KGzIZU3RydWN0dXJlZCBhdXhpbGlhcnkgZGF0",
-            "YSLoCAoFVHJhY2USQQoKY29tcG9uZW50cxgBIAMoCzIhLmNlcmJvcy5lbmdp",
-            "bmUudjEuVHJhY2UuQ29tcG9uZW50Ugpjb21wb25lbnRzEjMKBWV2ZW50GAIg",
-            "ASgLMh0uY2VyYm9zLmVuZ2luZS52MS5UcmFjZS5FdmVudFIFZXZlbnQawAUK",
-            "CUNvbXBvbmVudBI6CgRraW5kGAEgASgOMiYuY2VyYm9zLmVuZ2luZS52MS5U",
-            "cmFjZS5Db21wb25lbnQuS2luZFIEa2luZBIYCgZhY3Rpb24YAiABKAlIAFIG",
-            "YWN0aW9uEiMKDGRlcml2ZWRfcm9sZRgDIAEoCUgAUgtkZXJpdmVkUm9sZRIU",
-            "CgRleHByGAQgASgJSABSBGV4cHISFgoFaW5kZXgYBSABKA1IAFIFaW5kZXgS",
-            "GAoGcG9saWN5GAYgASgJSABSBnBvbGljeRIcCghyZXNvdXJjZRgHIAEoCUgA",
-            "UghyZXNvdXJjZRIUCgRydWxlGAggASgJSABSBHJ1bGUSFgoFc2NvcGUYCSAB",
-            "KAlIAFIFc2NvcGUSSAoIdmFyaWFibGUYCiABKAsyKi5jZXJib3MuZW5naW5l",
-            "LnYxLlRyYWNlLkNvbXBvbmVudC5WYXJpYWJsZUgAUgh2YXJpYWJsZRoyCghW",
-            "YXJpYWJsZRISCgRuYW1lGAEgASgJUgRuYW1lEhIKBGV4cHIYAiABKAlSBGV4",
-            "cHIimgIKBEtpbmQSFAoQS0lORF9VTlNQRUNJRklFRBAAEg8KC0tJTkRfQUNU",
-            "SU9OEAESFgoSS0lORF9DT05ESVRJT05fQUxMEAISFgoSS0lORF9DT05ESVRJ",
-            "T05fQU5ZEAMSFwoTS0lORF9DT05ESVRJT05fTk9ORRAEEhIKDktJTkRfQ09O",
-            "RElUSU9OEAUSFQoRS0lORF9ERVJJVkVEX1JPTEUQBhINCglLSU5EX0VYUFIQ",
-            "BxIPCgtLSU5EX1BPTElDWRAIEhEKDUtJTkRfUkVTT1VSQ0UQCRINCglLSU5E",
-            "X1JVTEUQChIOCgpLSU5EX1NDT1BFEAsSEQoNS0lORF9WQVJJQUJMRRAMEhIK",
-            "DktJTkRfVkFSSUFCTEVTEA1CCQoHZGV0YWlscxqjAgoFRXZlbnQSPAoGc3Rh",
-            "dHVzGAEgASgOMiQuY2VyYm9zLmVuZ2luZS52MS5UcmFjZS5FdmVudC5TdGF0",
-            "dXNSBnN0YXR1cxIwCgZlZmZlY3QYAiABKA4yGC5jZXJib3MuZWZmZWN0LnYx",
-            "LkVmZmVjdFIGZWZmZWN0EhQKBWVycm9yGAMgASgJUgVlcnJvchIYCgdtZXNz",
-            "YWdlGAQgASgJUgdtZXNzYWdlEi4KBnJlc3VsdBgFIAEoCzIWLmdvb2dsZS5w",
-            "cm90b2J1Zi5WYWx1ZVIGcmVzdWx0IkoKBlN0YXR1cxIWChJTVEFUVVNfVU5T",
-            "UEVDSUZJRUQQABIUChBTVEFUVVNfQUNUSVZBVEVEEAESEgoOU1RBVFVTX1NL",
-            "SVBQRUQQAkJvChhkZXYuY2VyYm9zLmFwaS52MS5lbmdpbmVaPGdpdGh1Yi5j",
-            "b20vY2VyYm9zL2NlcmJvcy9hcGkvZ2VucGIvY2VyYm9zL2VuZ2luZS92MTtl",
-            "bmdpbmV2MaoCFENlcmJvcy5BcGkuVjEuRW5naW5lYgZwcm90bzM="));
+            "c2NoZW1hLnYxLlZhbGlkYXRpb25FcnJvclIQdmFsaWRhdGlvbkVycm9ycxI3",
+            "CgdvdXRwdXRzGAYgAygLMh0uY2VyYm9zLmVuZ2luZS52MS5PdXRwdXRFbnRy",
+            "eVIHb3V0cHV0cxpuCgxBY3Rpb25FZmZlY3QSMAoGZWZmZWN0GAEgASgOMhgu",
+            "Y2VyYm9zLmVmZmVjdC52MS5FZmZlY3RSBmVmZmVjdBIWCgZwb2xpY3kYAiAB",
+            "KAlSBnBvbGljeRIUCgVzY29wZRgDIAEoCVIFc2NvcGUaZgoMQWN0aW9uc0Vu",
+            "dHJ5EhAKA2tleRgBIAEoCVIDa2V5EkAKBXZhbHVlGAIgASgLMiouY2VyYm9z",
+            "LmVuZ2luZS52MS5DaGVja091dHB1dC5BY3Rpb25FZmZlY3RSBXZhbHVlOgI4",
+            "ASLrAQoLT3V0cHV0RW50cnkSZQoDc3JjGAEgASgJQlOSQVAyKVJ1bGUgdGhh",
+            "dCBtYXRjaGVkIHRvIHByb2R1Y2UgdGhpcyBvdXRwdXQuSiMicmVzb3VyY2Uu",
+            "ZXhwZW5zZS52MS9hY21lI3J1bGUtMDAxIlIDc3JjEnUKA3ZhbBgCIAEoCzIW",
+            "Lmdvb2dsZS5wcm90b2J1Zi5WYWx1ZUJLkkFIMjdEeW5hbWljIG91dHB1dCwg",
+            "ZGV0ZXJtaW5lZCBieSB1c2VyIGRlZmluZWQgcnVsZSBvdXRwdXQuSg0ic29t",
+            "ZV9zdHJpbmciUgN2YWwiwAgKCFJlc291cmNlEuEBCgRraW5kGAEgASgJQswB",
+            "kkF8MilOYW1lIG9mIHRoZSByZXNvdXJjZSBraW5kIGJlaW5nIGFjY2Vzc2Vk",
+            "LkoNImFsYnVtOnBob3RvIooBP15bWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5c",
+            "LV0qKFw6W1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwuXC1dKikqJOBBAvpCR3JF",
+            "EAEyQV5bWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5cLS9dKihcOltbOmFscGhh",
+            "Ol1dW1s6d29yZDpdXEBcLlwtL10qKSokUgRraW5kEtwBCg5wb2xpY3lfdmVy",
+            "c2lvbhgCIAEoCUK0AZJBmQEyfFRoZSBwb2xpY3kgdmVyc2lvbiB0byB1c2Ug",
+            "dG8gZXZhbHVhdGUgdGhpcyByZXF1ZXN0LiBJZiBub3Qgc3BlY2lmaWVkLCB3",
+            "aWxsIGRlZmF1bHQgdG8gdGhlIHNlcnZlci1jb25maWd1cmVkIGRlZmF1bHQg",
+            "dmVyc2lvbi5KCSJkZWZhdWx0IooBDV5bWzp3b3JkOl1dKiTgQQH6QhFyDzIN",
+            "XltbOndvcmQ6XV0qJFINcG9saWN5VmVyc2lvbhJDCgJpZBgDIAEoCUIzkkEm",
+            "MhtJRCBvZiB0aGUgcmVzb3VyY2UgaW5zdGFuY2VKByJYWDEyNSLgQQL6QgRy",
+            "AhABUgJpZBLFAQoEYXR0chgEIAMoCzIkLmNlcmJvcy5lbmdpbmUudjEuUmVz",
+            "b3VyY2UuQXR0ckVudHJ5QooBkkF/MmRLYXktdmFsdWUgcGFpcnMgb2YgY29u",
+            "dGV4dHVhbCBkYXRhIGFib3V0IHRoaXMgcmVzb3VyY2UgdGhhdCBzaG91bGQg",
+            "YmUgdXNlZCBkdXJpbmcgcG9saWN5IGV2YWx1YXRpb24uShd7Im93bmVyIjog",
+            "ImJ1Z3NfYnVubnkiffpCBZoBAhgBUgRhdHRyEpICCgVzY29wZRgFIAEoCUL7",
+            "AZJBvgEyfUEgZG90LXNlcGFyYXRlZCBzY29wZSB0aGF0IGRlc2NyaWJlcyB0",
+            "aGUgaGllcmFyY2h5IHRoaXMgcmVzb3VyY2UgYmVsb25ncyB0by4gVGhpcyBp",
+            "cyB1c2VkIGZvciBkZXRlcm1pbmluZyBwb2xpY3kgaW5oZXJpdGFuY2UuSgsi",
+            "YWNtZS5jb3JwIooBL14oW1s6YWxudW06XV1bWzp3b3JkOl1cLV0qKFwuW1s6",
+            "d29yZDpdXC1dKikqKSok4EEB+kIzcjEyL14oW1s6YWxudW06XV1bWzp3b3Jk",
+            "Ol1cLV0qKFwuW1s6d29yZDpdXC1dKikqKSokUgVzY29wZRpPCglBdHRyRW50",
+            "cnkSEAoDa2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiABKAsyFi5nb29nbGUu",
+            "cHJvdG9idWYuVmFsdWVSBXZhbHVlOgI4ASLjCAoJUHJpbmNpcGFsEkAKAmlk",
+            "GAEgASgJQjCSQSMyE0lEIG9mIHRoZSBwcmluY2lwYWxKDCJidWdzX2J1bm55",
+            "IuBBAvpCBHICEAFSAmlkEtwBCg5wb2xpY3lfdmVyc2lvbhgCIAEoCUK0AZJB",
+            "mQEyfFRoZSBwb2xpY3kgdmVyc2lvbiB0byB1c2UgdG8gZXZhbHVhdGUgdGhp",
+            "cyByZXF1ZXN0LiBJZiBub3Qgc3BlY2lmaWVkLCB3aWxsIGRlZmF1bHQgdG8g",
+            "dGhlIHNlcnZlci1jb25maWd1cmVkIGRlZmF1bHQgdmVyc2lvbi5KCSJkZWZh",
+            "dWx0IooBDV5bWzp3b3JkOl1dKiTgQQH6QhFyDzINXltbOndvcmQ6XV0qJFIN",
+            "cG9saWN5VmVyc2lvbhKqAQoFcm9sZXMYAyADKAlCkwGSQWwyRlJvbGVzIGFz",
+            "c2lnbmVkIHRvIHRoaXMgcHJpbmNpcGFsIGZyb20geW91ciBpZGVudGl0eSBt",
+            "YW5hZ2VtZW50IHN5c3RlbS5KCFsidXNlciJdigERXltbOndvcmQ6XVwtXC5d",
+            "KySoAQGwAQHgQQL6Qh6SARsIARgBIhVyEzIRXltbOndvcmQ6XVwtXC5dKyRS",
+            "BXJvbGVzEsUBCgRhdHRyGAQgAygLMiUuY2VyYm9zLmVuZ2luZS52MS5Qcmlu",
+            "Y2lwYWwuQXR0ckVudHJ5QokBkkF+MmVLZXktdmFsdWUgcGFpcnMgb2YgY29u",
+            "dGV4dHVhbCBkYXRhIGFib3V0IHRoaXMgcHJpbmNpcGFsIHRoYXQgc2hvdWxk",
+            "IGJlIHVzZWQgZHVyaW5nIHBvbGljeSBldmFsdWF0aW9uLkoVeyJiZXRhX3Rl",
+            "c3RlciI6IHRydWV9+kIFmgECGAFSBGF0dHISkwIKBXNjb3BlGAUgASgJQvwB",
+            "kkG/ATJ+QSBkb3Qtc2VwYXJhdGVkIHNjb3BlIHRoYXQgZGVzY3JpYmVzIHRo",
+            "ZSBoaWVyYXJjaHkgdGhpcyBwcmluY2lwYWwgYmVsb25ncyB0by4gVGhpcyBp",
+            "cyB1c2VkIGZvciBkZXRlcm1pbmluZyBwb2xpY3kgaW5oZXJpdGFuY2UuSgsi",
+            "YWNtZS5jb3JwIooBL14oW1s6YWxudW06XV1bWzp3b3JkOl1cLV0qKFwuW1s6",
+            "d29yZDpdXC1dKikqKSok4EEB+kIzcjEyL14oW1s6YWxudW06XV1bWzp3b3Jk",
+            "Ol1cLV0qKFwuW1s6d29yZDpdXC1dKikqKSokUgVzY29wZRpPCglBdHRyRW50",
+            "cnkSEAoDa2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiABKAsyFi5nb29nbGUu",
+            "cHJvdG9idWYuVmFsdWVSBXZhbHVlOgI4ATpZkkFWClQyUkEgcGVyc29uIG9y",
+            "IGFwcGxpY2F0aW9uIGF0dGVtcHRpbmcgdG8gcGVyZm9ybSB0aGUgYWN0aW9u",
+            "cyBvbiB0aGUgc2V0IG9mIHJlc291cmNlcy4isQEKB0F1eERhdGESNAoDand0",
+            "GAEgAygLMiIuY2VyYm9zLmVuZ2luZS52MS5BdXhEYXRhLkp3dEVudHJ5UgNq",
+            "d3QaTgoISnd0RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiAB",
+            "KAsyFi5nb29nbGUucHJvdG9idWYuVmFsdWVSBXZhbHVlOgI4ATogkkEdChsy",
+            "GVN0cnVjdHVyZWQgYXV4aWxpYXJ5IGRhdGEikwkKBVRyYWNlEkEKCmNvbXBv",
+            "bmVudHMYASADKAsyIS5jZXJib3MuZW5naW5lLnYxLlRyYWNlLkNvbXBvbmVu",
+            "dFIKY29tcG9uZW50cxIzCgVldmVudBgCIAEoCzIdLmNlcmJvcy5lbmdpbmUu",
+            "djEuVHJhY2UuRXZlbnRSBWV2ZW50GusFCglDb21wb25lbnQSOgoEa2luZBgB",
+            "IAEoDjImLmNlcmJvcy5lbmdpbmUudjEuVHJhY2UuQ29tcG9uZW50LktpbmRS",
+            "BGtpbmQSGAoGYWN0aW9uGAIgASgJSABSBmFjdGlvbhIjCgxkZXJpdmVkX3Jv",
+            "bGUYAyABKAlIAFILZGVyaXZlZFJvbGUSFAoEZXhwchgEIAEoCUgAUgRleHBy",
+            "EhYKBWluZGV4GAUgASgNSABSBWluZGV4EhgKBnBvbGljeRgGIAEoCUgAUgZw",
+            "b2xpY3kSHAoIcmVzb3VyY2UYByABKAlIAFIIcmVzb3VyY2USFAoEcnVsZRgI",
+            "IAEoCUgAUgRydWxlEhYKBXNjb3BlGAkgASgJSABSBXNjb3BlEkgKCHZhcmlh",
+            "YmxlGAogASgLMiouY2VyYm9zLmVuZ2luZS52MS5UcmFjZS5Db21wb25lbnQu",
+            "VmFyaWFibGVIAFIIdmFyaWFibGUSGAoGb3V0cHV0GAsgASgJSABSBm91dHB1",
+            "dBoyCghWYXJpYWJsZRISCgRuYW1lGAEgASgJUgRuYW1lEhIKBGV4cHIYAiAB",
+            "KAlSBGV4cHIiqwIKBEtpbmQSFAoQS0lORF9VTlNQRUNJRklFRBAAEg8KC0tJ",
+            "TkRfQUNUSU9OEAESFgoSS0lORF9DT05ESVRJT05fQUxMEAISFgoSS0lORF9D",
+            "T05ESVRJT05fQU5ZEAMSFwoTS0lORF9DT05ESVRJT05fTk9ORRAEEhIKDktJ",
+            "TkRfQ09ORElUSU9OEAUSFQoRS0lORF9ERVJJVkVEX1JPTEUQBhINCglLSU5E",
+            "X0VYUFIQBxIPCgtLSU5EX1BPTElDWRAIEhEKDUtJTkRfUkVTT1VSQ0UQCRIN",
+            "CglLSU5EX1JVTEUQChIOCgpLSU5EX1NDT1BFEAsSEQoNS0lORF9WQVJJQUJM",
+            "RRAMEhIKDktJTkRfVkFSSUFCTEVTEA0SDwoLS0lORF9PVVRQVVQQDkIJCgdk",
+            "ZXRhaWxzGqMCCgVFdmVudBI8CgZzdGF0dXMYASABKA4yJC5jZXJib3MuZW5n",
+            "aW5lLnYxLlRyYWNlLkV2ZW50LlN0YXR1c1IGc3RhdHVzEjAKBmVmZmVjdBgC",
+            "IAEoDjIYLmNlcmJvcy5lZmZlY3QudjEuRWZmZWN0UgZlZmZlY3QSFAoFZXJy",
+            "b3IYAyABKAlSBWVycm9yEhgKB21lc3NhZ2UYBCABKAlSB21lc3NhZ2USLgoG",
+            "cmVzdWx0GAUgASgLMhYuZ29vZ2xlLnByb3RvYnVmLlZhbHVlUgZyZXN1bHQi",
+            "SgoGU3RhdHVzEhYKElNUQVRVU19VTlNQRUNJRklFRBAAEhQKEFNUQVRVU19B",
+            "Q1RJVkFURUQQARISCg5TVEFUVVNfU0tJUFBFRBACQm8KGGRldi5jZXJib3Mu",
+            "YXBpLnYxLmVuZ2luZVo8Z2l0aHViLmNvbS9jZXJib3MvY2VyYm9zL2FwaS9n",
+            "ZW5wYi9jZXJib3MvZW5naW5lL3YxO2VuZ2luZXYxqgIUQ2VyYm9zLkFwaS5W",
+            "MS5FbmdpbmViBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Effect.EffectReflection.Descriptor, global::Cerbos.Api.V1.Schema.SchemaReflection.Descriptor, global::Google.Api.Expr.V1Alpha1.CheckedReflection.Descriptor, global::Google.Api.FieldBehaviorReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Grpc.Gateway.ProtocGenOpenapiv2.Options.AnnotationsReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -204,12 +212,13 @@ namespace Cerbos.Api.V1.Engine {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.PlanResourcesFilter), global::Cerbos.Api.V1.Engine.PlanResourcesFilter.Parser, new[]{ "Kind", "Condition" }, null, new[]{ typeof(global::Cerbos.Api.V1.Engine.PlanResourcesFilter.Types.Kind) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.PlanResourcesFilter.Types.Expression), global::Cerbos.Api.V1.Engine.PlanResourcesFilter.Types.Expression.Parser, new[]{ "Operator", "Operands" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.PlanResourcesFilter.Types.Expression.Types.Operand), global::Cerbos.Api.V1.Engine.PlanResourcesFilter.Types.Expression.Types.Operand.Parser, new[]{ "Value", "Expression", "Variable" }, new[]{ "Node" }, null, null, null)})}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.PlanResourcesOutput), global::Cerbos.Api.V1.Engine.PlanResourcesOutput.Parser, new[]{ "RequestId", "Action", "Kind", "PolicyVersion", "Scope", "Filter", "FilterDebug", "ValidationErrors" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.CheckInput), global::Cerbos.Api.V1.Engine.CheckInput.Parser, new[]{ "RequestId", "Resource", "Principal", "Actions", "AuxData" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.CheckOutput), global::Cerbos.Api.V1.Engine.CheckOutput.Parser, new[]{ "RequestId", "ResourceId", "Actions", "EffectiveDerivedRoles", "ValidationErrors" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.CheckOutput.Types.ActionEffect), global::Cerbos.Api.V1.Engine.CheckOutput.Types.ActionEffect.Parser, new[]{ "Effect", "Policy", "Scope" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.CheckOutput), global::Cerbos.Api.V1.Engine.CheckOutput.Parser, new[]{ "RequestId", "ResourceId", "Actions", "EffectiveDerivedRoles", "ValidationErrors", "Outputs" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.CheckOutput.Types.ActionEffect), global::Cerbos.Api.V1.Engine.CheckOutput.Types.ActionEffect.Parser, new[]{ "Effect", "Policy", "Scope" }, null, null, null, null),
             null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.OutputEntry), global::Cerbos.Api.V1.Engine.OutputEntry.Parser, new[]{ "Src", "Val" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Resource), global::Cerbos.Api.V1.Engine.Resource.Parser, new[]{ "Kind", "PolicyVersion", "Id", "Attr", "Scope" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Principal), global::Cerbos.Api.V1.Engine.Principal.Parser, new[]{ "Id", "PolicyVersion", "Roles", "Attr", "Scope" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.AuxData), global::Cerbos.Api.V1.Engine.AuxData.Parser, new[]{ "Jwt" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace), global::Cerbos.Api.V1.Engine.Trace.Parser, new[]{ "Components", "Event" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Component), global::Cerbos.Api.V1.Engine.Trace.Types.Component.Parser, new[]{ "Kind", "Action", "DerivedRole", "Expr", "Index", "Policy", "Resource", "Rule", "Scope", "Variable" }, new[]{ "Details" }, new[]{ typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Kind) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Variable), global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Variable.Parser, new[]{ "Name", "Expr" }, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace), global::Cerbos.Api.V1.Engine.Trace.Parser, new[]{ "Components", "Event" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Component), global::Cerbos.Api.V1.Engine.Trace.Types.Component.Parser, new[]{ "Kind", "Action", "DerivedRole", "Expr", "Index", "Policy", "Resource", "Rule", "Scope", "Variable", "Output" }, new[]{ "Details" }, new[]{ typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Kind) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Variable), global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Variable.Parser, new[]{ "Name", "Expr" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Event), global::Cerbos.Api.V1.Engine.Trace.Types.Event.Parser, new[]{ "Status", "Effect", "Error", "Message", "Result" }, null, new[]{ typeof(global::Cerbos.Api.V1.Engine.Trace.Types.Event.Types.Status) }, null, null)})
           }));
     }
@@ -834,7 +843,7 @@ namespace Cerbos.Api.V1.Engine {
           if (other.Kind.Length != 0) {
             Kind = other.Kind;
           }
-          attr_.Add(other.attr_);
+          attr_.MergeFrom(other.attr_);
           if (other.PolicyVersion.Length != 0) {
             PolicyVersion = other.PolicyVersion;
           }
@@ -2183,10 +2192,24 @@ namespace Cerbos.Api.V1.Engine {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
             public string Variable {
-              get { return nodeCase_ == NodeOneofCase.Variable ? (string) node_ : ""; }
+              get { return HasVariable ? (string) node_ : ""; }
               set {
                 node_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
                 nodeCase_ = NodeOneofCase.Variable;
+              }
+            }
+            /// <summary>Gets whether the "variable" field is set</summary>
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public bool HasVariable {
+              get { return nodeCase_ == NodeOneofCase.Variable; }
+            }
+            /// <summary> Clears the value of the oneof if it's currently set to "variable" </summary>
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void ClearVariable() {
+              if (HasVariable) {
+                ClearNode();
               }
             }
 
@@ -2240,7 +2263,7 @@ namespace Cerbos.Api.V1.Engine {
               int hash = 1;
               if (nodeCase_ == NodeOneofCase.Value) hash ^= Value.GetHashCode();
               if (nodeCase_ == NodeOneofCase.Expression) hash ^= Expression.GetHashCode();
-              if (nodeCase_ == NodeOneofCase.Variable) hash ^= Variable.GetHashCode();
+              if (HasVariable) hash ^= Variable.GetHashCode();
               hash ^= (int) nodeCase_;
               if (_unknownFields != null) {
                 hash ^= _unknownFields.GetHashCode();
@@ -2268,7 +2291,7 @@ namespace Cerbos.Api.V1.Engine {
                 output.WriteRawTag(18);
                 output.WriteMessage(Expression);
               }
-              if (nodeCase_ == NodeOneofCase.Variable) {
+              if (HasVariable) {
                 output.WriteRawTag(26);
                 output.WriteString(Variable);
               }
@@ -2290,7 +2313,7 @@ namespace Cerbos.Api.V1.Engine {
                 output.WriteRawTag(18);
                 output.WriteMessage(Expression);
               }
-              if (nodeCase_ == NodeOneofCase.Variable) {
+              if (HasVariable) {
                 output.WriteRawTag(26);
                 output.WriteString(Variable);
               }
@@ -2310,7 +2333,7 @@ namespace Cerbos.Api.V1.Engine {
               if (nodeCase_ == NodeOneofCase.Expression) {
                 size += 1 + pb::CodedOutputStream.ComputeMessageSize(Expression);
               }
-              if (nodeCase_ == NodeOneofCase.Variable) {
+              if (HasVariable) {
                 size += 1 + pb::CodedOutputStream.ComputeStringSize(Variable);
               }
               if (_unknownFields != null) {
@@ -3272,6 +3295,7 @@ namespace Cerbos.Api.V1.Engine {
       actions_ = other.actions_.Clone();
       effectiveDerivedRoles_ = other.effectiveDerivedRoles_.Clone();
       validationErrors_ = other.validationErrors_.Clone();
+      outputs_ = other.outputs_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -3338,6 +3362,17 @@ namespace Cerbos.Api.V1.Engine {
       get { return validationErrors_; }
     }
 
+    /// <summary>Field number for the "outputs" field.</summary>
+    public const int OutputsFieldNumber = 6;
+    private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Engine.OutputEntry> _repeated_outputs_codec
+        = pb::FieldCodec.ForMessage(50, global::Cerbos.Api.V1.Engine.OutputEntry.Parser);
+    private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> outputs_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> Outputs {
+      get { return outputs_; }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -3358,6 +3393,7 @@ namespace Cerbos.Api.V1.Engine {
       if (!Actions.Equals(other.Actions)) return false;
       if(!effectiveDerivedRoles_.Equals(other.effectiveDerivedRoles_)) return false;
       if(!validationErrors_.Equals(other.validationErrors_)) return false;
+      if(!outputs_.Equals(other.outputs_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -3370,6 +3406,7 @@ namespace Cerbos.Api.V1.Engine {
       hash ^= Actions.GetHashCode();
       hash ^= effectiveDerivedRoles_.GetHashCode();
       hash ^= validationErrors_.GetHashCode();
+      hash ^= outputs_.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3399,6 +3436,7 @@ namespace Cerbos.Api.V1.Engine {
       actions_.WriteTo(output, _map_actions_codec);
       effectiveDerivedRoles_.WriteTo(output, _repeated_effectiveDerivedRoles_codec);
       validationErrors_.WriteTo(output, _repeated_validationErrors_codec);
+      outputs_.WriteTo(output, _repeated_outputs_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -3420,6 +3458,7 @@ namespace Cerbos.Api.V1.Engine {
       actions_.WriteTo(ref output, _map_actions_codec);
       effectiveDerivedRoles_.WriteTo(ref output, _repeated_effectiveDerivedRoles_codec);
       validationErrors_.WriteTo(ref output, _repeated_validationErrors_codec);
+      outputs_.WriteTo(ref output, _repeated_outputs_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -3439,6 +3478,7 @@ namespace Cerbos.Api.V1.Engine {
       size += actions_.CalculateSize(_map_actions_codec);
       size += effectiveDerivedRoles_.CalculateSize(_repeated_effectiveDerivedRoles_codec);
       size += validationErrors_.CalculateSize(_repeated_validationErrors_codec);
+      size += outputs_.CalculateSize(_repeated_outputs_codec);
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -3457,9 +3497,10 @@ namespace Cerbos.Api.V1.Engine {
       if (other.ResourceId.Length != 0) {
         ResourceId = other.ResourceId;
       }
-      actions_.Add(other.actions_);
+      actions_.MergeFrom(other.actions_);
       effectiveDerivedRoles_.Add(other.effectiveDerivedRoles_);
       validationErrors_.Add(other.validationErrors_);
+      outputs_.Add(other.outputs_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -3495,6 +3536,10 @@ namespace Cerbos.Api.V1.Engine {
             validationErrors_.AddEntriesFrom(input, _repeated_validationErrors_codec);
             break;
           }
+          case 50: {
+            outputs_.AddEntriesFrom(input, _repeated_outputs_codec);
+            break;
+          }
         }
       }
     #endif
@@ -3528,6 +3573,10 @@ namespace Cerbos.Api.V1.Engine {
           }
           case 42: {
             validationErrors_.AddEntriesFrom(ref input, _repeated_validationErrors_codec);
+            break;
+          }
+          case 50: {
+            outputs_.AddEntriesFrom(ref input, _repeated_outputs_codec);
             break;
           }
         }
@@ -3808,6 +3857,241 @@ namespace Cerbos.Api.V1.Engine {
 
   }
 
+  public sealed partial class OutputEntry : pb::IMessage<OutputEntry>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<OutputEntry> _parser = new pb::MessageParser<OutputEntry>(() => new OutputEntry());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<OutputEntry> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[6]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public OutputEntry() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public OutputEntry(OutputEntry other) : this() {
+      src_ = other.src_;
+      val_ = other.val_ != null ? other.val_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public OutputEntry Clone() {
+      return new OutputEntry(this);
+    }
+
+    /// <summary>Field number for the "src" field.</summary>
+    public const int SrcFieldNumber = 1;
+    private string src_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Src {
+      get { return src_; }
+      set {
+        src_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "val" field.</summary>
+    public const int ValFieldNumber = 2;
+    private global::Google.Protobuf.WellKnownTypes.Value val_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.WellKnownTypes.Value Val {
+      get { return val_; }
+      set {
+        val_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as OutputEntry);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(OutputEntry other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Src != other.Src) return false;
+      if (!object.Equals(Val, other.Val)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Src.Length != 0) hash ^= Src.GetHashCode();
+      if (val_ != null) hash ^= Val.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Src.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Src);
+      }
+      if (val_ != null) {
+        output.WriteRawTag(18);
+        output.WriteMessage(Val);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Src.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Src);
+      }
+      if (val_ != null) {
+        output.WriteRawTag(18);
+        output.WriteMessage(Val);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Src.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Src);
+      }
+      if (val_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Val);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(OutputEntry other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Src.Length != 0) {
+        Src = other.Src;
+      }
+      if (other.val_ != null) {
+        if (val_ == null) {
+          Val = new global::Google.Protobuf.WellKnownTypes.Value();
+        }
+        Val.MergeFrom(other.Val);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Src = input.ReadString();
+            break;
+          }
+          case 18: {
+            if (val_ == null) {
+              Val = new global::Google.Protobuf.WellKnownTypes.Value();
+            }
+            input.ReadMessage(Val);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            Src = input.ReadString();
+            break;
+          }
+          case 18: {
+            if (val_ == null) {
+              Val = new global::Google.Protobuf.WellKnownTypes.Value();
+            }
+            input.ReadMessage(Val);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   public sealed partial class Resource : pb::IMessage<Resource>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3822,7 +4106,7 @@ namespace Cerbos.Api.V1.Engine {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[6]; }
+      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4053,7 +4337,7 @@ namespace Cerbos.Api.V1.Engine {
       if (other.Id.Length != 0) {
         Id = other.Id;
       }
-      attr_.Add(other.attr_);
+      attr_.MergeFrom(other.attr_);
       if (other.Scope.Length != 0) {
         Scope = other.Scope;
       }
@@ -4148,7 +4432,7 @@ namespace Cerbos.Api.V1.Engine {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[7]; }
+      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4368,7 +4652,7 @@ namespace Cerbos.Api.V1.Engine {
         PolicyVersion = other.PolicyVersion;
       }
       roles_.Add(other.roles_);
-      attr_.Add(other.attr_);
+      attr_.MergeFrom(other.attr_);
       if (other.Scope.Length != 0) {
         Scope = other.Scope;
       }
@@ -4463,7 +4747,7 @@ namespace Cerbos.Api.V1.Engine {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[8]; }
+      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[9]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4581,7 +4865,7 @@ namespace Cerbos.Api.V1.Engine {
       if (other == null) {
         return;
       }
-      jwt_.Add(other.jwt_);
+      jwt_.MergeFrom(other.jwt_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -4641,7 +4925,7 @@ namespace Cerbos.Api.V1.Engine {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[9]; }
+      get { return global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4917,6 +5201,9 @@ namespace Cerbos.Api.V1.Engine {
             case DetailsOneofCase.Variable:
               Variable = other.Variable.Clone();
               break;
+            case DetailsOneofCase.Output:
+              Output = other.Output;
+              break;
           }
 
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -4945,10 +5232,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Action {
-          get { return detailsCase_ == DetailsOneofCase.Action ? (string) details_ : ""; }
+          get { return HasAction ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.Action;
+          }
+        }
+        /// <summary>Gets whether the "action" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasAction {
+          get { return detailsCase_ == DetailsOneofCase.Action; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "action" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearAction() {
+          if (HasAction) {
+            ClearDetails();
           }
         }
 
@@ -4957,10 +5258,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string DerivedRole {
-          get { return detailsCase_ == DetailsOneofCase.DerivedRole ? (string) details_ : ""; }
+          get { return HasDerivedRole ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.DerivedRole;
+          }
+        }
+        /// <summary>Gets whether the "derived_role" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasDerivedRole {
+          get { return detailsCase_ == DetailsOneofCase.DerivedRole; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "derived_role" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearDerivedRole() {
+          if (HasDerivedRole) {
+            ClearDetails();
           }
         }
 
@@ -4969,10 +5284,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Expr {
-          get { return detailsCase_ == DetailsOneofCase.Expr ? (string) details_ : ""; }
+          get { return HasExpr ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.Expr;
+          }
+        }
+        /// <summary>Gets whether the "expr" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasExpr {
+          get { return detailsCase_ == DetailsOneofCase.Expr; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "expr" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearExpr() {
+          if (HasExpr) {
+            ClearDetails();
           }
         }
 
@@ -4981,10 +5310,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public uint Index {
-          get { return detailsCase_ == DetailsOneofCase.Index ? (uint) details_ : 0; }
+          get { return HasIndex ? (uint) details_ : 0; }
           set {
             details_ = value;
             detailsCase_ = DetailsOneofCase.Index;
+          }
+        }
+        /// <summary>Gets whether the "index" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasIndex {
+          get { return detailsCase_ == DetailsOneofCase.Index; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "index" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearIndex() {
+          if (HasIndex) {
+            ClearDetails();
           }
         }
 
@@ -4993,10 +5336,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Policy {
-          get { return detailsCase_ == DetailsOneofCase.Policy ? (string) details_ : ""; }
+          get { return HasPolicy ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.Policy;
+          }
+        }
+        /// <summary>Gets whether the "policy" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasPolicy {
+          get { return detailsCase_ == DetailsOneofCase.Policy; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "policy" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearPolicy() {
+          if (HasPolicy) {
+            ClearDetails();
           }
         }
 
@@ -5005,10 +5362,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Resource {
-          get { return detailsCase_ == DetailsOneofCase.Resource ? (string) details_ : ""; }
+          get { return HasResource ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.Resource;
+          }
+        }
+        /// <summary>Gets whether the "resource" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasResource {
+          get { return detailsCase_ == DetailsOneofCase.Resource; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "resource" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearResource() {
+          if (HasResource) {
+            ClearDetails();
           }
         }
 
@@ -5017,10 +5388,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Rule {
-          get { return detailsCase_ == DetailsOneofCase.Rule ? (string) details_ : ""; }
+          get { return HasRule ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.Rule;
+          }
+        }
+        /// <summary>Gets whether the "rule" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasRule {
+          get { return detailsCase_ == DetailsOneofCase.Rule; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "rule" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearRule() {
+          if (HasRule) {
+            ClearDetails();
           }
         }
 
@@ -5029,10 +5414,24 @@ namespace Cerbos.Api.V1.Engine {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Scope {
-          get { return detailsCase_ == DetailsOneofCase.Scope ? (string) details_ : ""; }
+          get { return HasScope ? (string) details_ : ""; }
           set {
             details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             detailsCase_ = DetailsOneofCase.Scope;
+          }
+        }
+        /// <summary>Gets whether the "scope" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasScope {
+          get { return detailsCase_ == DetailsOneofCase.Scope; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "scope" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearScope() {
+          if (HasScope) {
+            ClearDetails();
           }
         }
 
@@ -5045,6 +5444,32 @@ namespace Cerbos.Api.V1.Engine {
           set {
             details_ = value;
             detailsCase_ = value == null ? DetailsOneofCase.None : DetailsOneofCase.Variable;
+          }
+        }
+
+        /// <summary>Field number for the "output" field.</summary>
+        public const int OutputFieldNumber = 11;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public string Output {
+          get { return HasOutput ? (string) details_ : ""; }
+          set {
+            details_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+            detailsCase_ = DetailsOneofCase.Output;
+          }
+        }
+        /// <summary>Gets whether the "output" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasOutput {
+          get { return detailsCase_ == DetailsOneofCase.Output; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "output" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearOutput() {
+          if (HasOutput) {
+            ClearDetails();
           }
         }
 
@@ -5061,6 +5486,7 @@ namespace Cerbos.Api.V1.Engine {
           Rule = 8,
           Scope = 9,
           Variable = 10,
+          Output = 11,
         }
         private DetailsOneofCase detailsCase_ = DetailsOneofCase.None;
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5101,6 +5527,7 @@ namespace Cerbos.Api.V1.Engine {
           if (Rule != other.Rule) return false;
           if (Scope != other.Scope) return false;
           if (!object.Equals(Variable, other.Variable)) return false;
+          if (Output != other.Output) return false;
           if (DetailsCase != other.DetailsCase) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
@@ -5110,15 +5537,16 @@ namespace Cerbos.Api.V1.Engine {
         public override int GetHashCode() {
           int hash = 1;
           if (Kind != global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Kind.Unspecified) hash ^= Kind.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Action) hash ^= Action.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.DerivedRole) hash ^= DerivedRole.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Expr) hash ^= Expr.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Index) hash ^= Index.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Policy) hash ^= Policy.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Resource) hash ^= Resource.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Rule) hash ^= Rule.GetHashCode();
-          if (detailsCase_ == DetailsOneofCase.Scope) hash ^= Scope.GetHashCode();
+          if (HasAction) hash ^= Action.GetHashCode();
+          if (HasDerivedRole) hash ^= DerivedRole.GetHashCode();
+          if (HasExpr) hash ^= Expr.GetHashCode();
+          if (HasIndex) hash ^= Index.GetHashCode();
+          if (HasPolicy) hash ^= Policy.GetHashCode();
+          if (HasResource) hash ^= Resource.GetHashCode();
+          if (HasRule) hash ^= Rule.GetHashCode();
+          if (HasScope) hash ^= Scope.GetHashCode();
           if (detailsCase_ == DetailsOneofCase.Variable) hash ^= Variable.GetHashCode();
+          if (HasOutput) hash ^= Output.GetHashCode();
           hash ^= (int) detailsCase_;
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
@@ -5142,41 +5570,45 @@ namespace Cerbos.Api.V1.Engine {
             output.WriteRawTag(8);
             output.WriteEnum((int) Kind);
           }
-          if (detailsCase_ == DetailsOneofCase.Action) {
+          if (HasAction) {
             output.WriteRawTag(18);
             output.WriteString(Action);
           }
-          if (detailsCase_ == DetailsOneofCase.DerivedRole) {
+          if (HasDerivedRole) {
             output.WriteRawTag(26);
             output.WriteString(DerivedRole);
           }
-          if (detailsCase_ == DetailsOneofCase.Expr) {
+          if (HasExpr) {
             output.WriteRawTag(34);
             output.WriteString(Expr);
           }
-          if (detailsCase_ == DetailsOneofCase.Index) {
+          if (HasIndex) {
             output.WriteRawTag(40);
             output.WriteUInt32(Index);
           }
-          if (detailsCase_ == DetailsOneofCase.Policy) {
+          if (HasPolicy) {
             output.WriteRawTag(50);
             output.WriteString(Policy);
           }
-          if (detailsCase_ == DetailsOneofCase.Resource) {
+          if (HasResource) {
             output.WriteRawTag(58);
             output.WriteString(Resource);
           }
-          if (detailsCase_ == DetailsOneofCase.Rule) {
+          if (HasRule) {
             output.WriteRawTag(66);
             output.WriteString(Rule);
           }
-          if (detailsCase_ == DetailsOneofCase.Scope) {
+          if (HasScope) {
             output.WriteRawTag(74);
             output.WriteString(Scope);
           }
           if (detailsCase_ == DetailsOneofCase.Variable) {
             output.WriteRawTag(82);
             output.WriteMessage(Variable);
+          }
+          if (HasOutput) {
+            output.WriteRawTag(90);
+            output.WriteString(Output);
           }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
@@ -5192,41 +5624,45 @@ namespace Cerbos.Api.V1.Engine {
             output.WriteRawTag(8);
             output.WriteEnum((int) Kind);
           }
-          if (detailsCase_ == DetailsOneofCase.Action) {
+          if (HasAction) {
             output.WriteRawTag(18);
             output.WriteString(Action);
           }
-          if (detailsCase_ == DetailsOneofCase.DerivedRole) {
+          if (HasDerivedRole) {
             output.WriteRawTag(26);
             output.WriteString(DerivedRole);
           }
-          if (detailsCase_ == DetailsOneofCase.Expr) {
+          if (HasExpr) {
             output.WriteRawTag(34);
             output.WriteString(Expr);
           }
-          if (detailsCase_ == DetailsOneofCase.Index) {
+          if (HasIndex) {
             output.WriteRawTag(40);
             output.WriteUInt32(Index);
           }
-          if (detailsCase_ == DetailsOneofCase.Policy) {
+          if (HasPolicy) {
             output.WriteRawTag(50);
             output.WriteString(Policy);
           }
-          if (detailsCase_ == DetailsOneofCase.Resource) {
+          if (HasResource) {
             output.WriteRawTag(58);
             output.WriteString(Resource);
           }
-          if (detailsCase_ == DetailsOneofCase.Rule) {
+          if (HasRule) {
             output.WriteRawTag(66);
             output.WriteString(Rule);
           }
-          if (detailsCase_ == DetailsOneofCase.Scope) {
+          if (HasScope) {
             output.WriteRawTag(74);
             output.WriteString(Scope);
           }
           if (detailsCase_ == DetailsOneofCase.Variable) {
             output.WriteRawTag(82);
             output.WriteMessage(Variable);
+          }
+          if (HasOutput) {
+            output.WriteRawTag(90);
+            output.WriteString(Output);
           }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
@@ -5241,32 +5677,35 @@ namespace Cerbos.Api.V1.Engine {
           if (Kind != global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Kind.Unspecified) {
             size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Kind);
           }
-          if (detailsCase_ == DetailsOneofCase.Action) {
+          if (HasAction) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Action);
           }
-          if (detailsCase_ == DetailsOneofCase.DerivedRole) {
+          if (HasDerivedRole) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(DerivedRole);
           }
-          if (detailsCase_ == DetailsOneofCase.Expr) {
+          if (HasExpr) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Expr);
           }
-          if (detailsCase_ == DetailsOneofCase.Index) {
+          if (HasIndex) {
             size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Index);
           }
-          if (detailsCase_ == DetailsOneofCase.Policy) {
+          if (HasPolicy) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Policy);
           }
-          if (detailsCase_ == DetailsOneofCase.Resource) {
+          if (HasResource) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Resource);
           }
-          if (detailsCase_ == DetailsOneofCase.Rule) {
+          if (HasRule) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Rule);
           }
-          if (detailsCase_ == DetailsOneofCase.Scope) {
+          if (HasScope) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Scope);
           }
           if (detailsCase_ == DetailsOneofCase.Variable) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(Variable);
+          }
+          if (HasOutput) {
+            size += 1 + pb::CodedOutputStream.ComputeStringSize(Output);
           }
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
@@ -5313,6 +5752,9 @@ namespace Cerbos.Api.V1.Engine {
                 Variable = new global::Cerbos.Api.V1.Engine.Trace.Types.Component.Types.Variable();
               }
               Variable.MergeFrom(other.Variable);
+              break;
+            case DetailsOneofCase.Output:
+              Output = other.Output;
               break;
           }
 
@@ -5376,6 +5818,10 @@ namespace Cerbos.Api.V1.Engine {
                 Variable = subBuilder;
                 break;
               }
+              case 90: {
+                Output = input.ReadString();
+                break;
+              }
             }
           }
         #endif
@@ -5436,6 +5882,10 @@ namespace Cerbos.Api.V1.Engine {
                 Variable = subBuilder;
                 break;
               }
+              case 90: {
+                Output = input.ReadString();
+                break;
+              }
             }
           }
         }
@@ -5461,6 +5911,7 @@ namespace Cerbos.Api.V1.Engine {
             [pbr::OriginalName("KIND_SCOPE")] Scope = 11,
             [pbr::OriginalName("KIND_VARIABLE")] Variable = 12,
             [pbr::OriginalName("KIND_VARIABLES")] Variables = 13,
+            [pbr::OriginalName("KIND_OUTPUT")] Output = 14,
           }
 
           public sealed partial class Variable : pb::IMessage<Variable>

--- a/src/Sdk/Cerbos/Api/V1/Policy/Policy.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Policy/Policy.g.cs
@@ -26,189 +26,214 @@ namespace Cerbos.Api.V1.Policy {
           string.Concat(
             "Ch1jZXJib3MvcG9saWN5L3YxL3BvbGljeS5wcm90bxIQY2VyYm9zLnBvbGlj",
             "eS52MRodY2VyYm9zL2VmZmVjdC92MS9lZmZlY3QucHJvdG8aHWNlcmJvcy9l",
-            "bmdpbmUvdjEvZW5naW5lLnByb3RvGh9nb29nbGUvcHJvdG9idWYvdGltZXN0",
-            "YW1wLnByb3RvGh5nb29nbGUvcHJvdG9idWYvd3JhcHBlcnMucHJvdG8aF3Zh",
-            "bGlkYXRlL3ZhbGlkYXRlLnByb3RvIrYECgZQb2xpY3kSOQoLYXBpX3ZlcnNp",
-            "b24YASABKAlCGPpCFXITChFhcGkuY2VyYm9zLmRldi92MVIKYXBpVmVyc2lv",
-            "bhIaCghkaXNhYmxlZBgCIAEoCFIIZGlzYWJsZWQSIAoLZGVzY3JpcHRpb24Y",
-            "AyABKAlSC2Rlc2NyaXB0aW9uEjYKCG1ldGFkYXRhGAQgASgLMhouY2VyYm9z",
-            "LnBvbGljeS52MS5NZXRhZGF0YVIIbWV0YWRhdGESSwoPcmVzb3VyY2VfcG9s",
-            "aWN5GAUgASgLMiAuY2VyYm9zLnBvbGljeS52MS5SZXNvdXJjZVBvbGljeUgA",
-            "Ug5yZXNvdXJjZVBvbGljeRJOChBwcmluY2lwYWxfcG9saWN5GAYgASgLMiEu",
-            "Y2VyYm9zLnBvbGljeS52MS5QcmluY2lwYWxQb2xpY3lIAFIPcHJpbmNpcGFs",
-            "UG9saWN5EkUKDWRlcml2ZWRfcm9sZXMYByABKAsyHi5jZXJib3MucG9saWN5",
-            "LnYxLkRlcml2ZWRSb2xlc0gAUgxkZXJpdmVkUm9sZXMSRQoJdmFyaWFibGVz",
-            "GAggAygLMicuY2VyYm9zLnBvbGljeS52MS5Qb2xpY3kuVmFyaWFibGVzRW50",
-            "cnlSCXZhcmlhYmxlcxo8Cg5WYXJpYWJsZXNFbnRyeRIQCgNrZXkYASABKAlS",
-            "A2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgBQhIKC3BvbGljeV90eXBl",
-            "EgP4QgEixAIKCE1ldGFkYXRhEh8KC3NvdXJjZV9maWxlGAEgASgJUgpzb3Vy",
-            "Y2VGaWxlEk0KC2Fubm90YXRpb25zGAIgAygLMisuY2VyYm9zLnBvbGljeS52",
-            "MS5NZXRhZGF0YS5Bbm5vdGF0aW9uc0VudHJ5Ugthbm5vdGF0aW9ucxIwCgRo",
-            "YXNoGAMgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlVJbnQ2NFZhbHVlUgRoYXNo",
-            "EisKD3N0b3JlX2lkZW50aWZlchgEIAEoCUICGAFSDnN0b3JlSWRlbnRpZmVy",
-            "EikKEHN0b3JlX2lkZW50aWZpZXIYBSABKAlSD3N0b3JlSWRlbnRpZmllcho+",
-            "ChBBbm5vdGF0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVl",
-            "GAIgASgJUgV2YWx1ZToCOAEitAMKDlJlc291cmNlUG9saWN5EmYKCHJlc291",
-            "cmNlGAEgASgJQkr6QkdyRRABMkFeW1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwu",
-            "XC0vXSooXDpbWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5cLS9dKikqJFIIcmVz",
-            "b3VyY2USLgoHdmVyc2lvbhgCIAEoCUIU+kIRcg8yDV5bWzp3b3JkOl1dKyRS",
-            "B3ZlcnNpb24SUQoUaW1wb3J0X2Rlcml2ZWRfcm9sZXMYAyADKAlCH/pCHJIB",
-            "GRgBIhVyEzIRXltbOndvcmQ6XVwtXC5dKyRSEmltcG9ydERlcml2ZWRSb2xl",
-            "cxI0CgVydWxlcxgEIAMoCzIeLmNlcmJvcy5wb2xpY3kudjEuUmVzb3VyY2VS",
-            "dWxlUgVydWxlcxJMCgVzY29wZRgFIAEoCUI2+kIzcjEyL14oW1s6YWxudW06",
-            "XV1bWzp3b3JkOl1cLV0qKFwuW1s6d29yZDpdXC1dKikqKSokUgVzY29wZRIz",
-            "CgdzY2hlbWFzGAYgASgLMhkuY2VyYm9zLnBvbGljeS52MS5TY2hlbWFzUgdz",
-            "Y2hlbWFzIqUDCgxSZXNvdXJjZVJ1bGUSKgoHYWN0aW9ucxgBIAMoCUIQ+kIN",
-            "kgEKCAEYASIEcgIQAVIHYWN0aW9ucxJECg1kZXJpdmVkX3JvbGVzGAIgAygJ",
-            "Qh/6QhySARkYASIVchMyEV5bWzp3b3JkOl1cLVwuXSskUgxkZXJpdmVkUm9s",
-            "ZXMSOgoFcm9sZXMYAyADKAlCJPpCIZIBHhgBIhpyGDIWXihbWzp3b3JkOl1c",
-            "LVwuXSt8XCopJFIFcm9sZXMSOQoJY29uZGl0aW9uGAQgASgLMhsuY2VyYm9z",
-            "LnBvbGljeS52MS5Db25kaXRpb25SCWNvbmRpdGlvbhI8CgZlZmZlY3QYBSAB",
-            "KA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVjdEIK+kIHggEEGAEYAlIGZWZm",
-            "ZWN0EjwKBG5hbWUYBiABKAlCKPpCJXIjMiFeKFtbOmFscGhhOl1dW1s6d29y",
-            "ZDpdXEBcLlwtXSopKiRSBG5hbWUSMAoGb3V0cHV0GAcgASgLMhguY2VyYm9z",
-            "LnBvbGljeS52MS5PdXRwdXRSBm91dHB1dCKuAgoPUHJpbmNpcGFsUG9saWN5",
-            "EmYKCXByaW5jaXBhbBgBIAEoCUJI+kJFckMQATI/XltbOmFscGhhOl1dW1s6",
-            "d29yZDpdXEBcLlwtXSooXDpbWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5cLV0q",
-            "KSokUglwcmluY2lwYWwSLgoHdmVyc2lvbhgCIAEoCUIU+kIRcg8yDV5bWzp3",
-            "b3JkOl1dKyRSB3ZlcnNpb24SNQoFcnVsZXMYAyADKAsyHy5jZXJib3MucG9s",
-            "aWN5LnYxLlByaW5jaXBhbFJ1bGVSBXJ1bGVzEkwKBXNjb3BlGAQgASgJQjb6",
-            "QjNyMTIvXihbWzphbG51bTpdXVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1c",
-            "LV0qKSopKiRSBXNjb3BlIpUDCg1QcmluY2lwYWxSdWxlEiMKCHJlc291cmNl",
-            "GAEgASgJQgf6QgRyAhABUghyZXNvdXJjZRJKCgdhY3Rpb25zGAIgAygLMiYu",
-            "Y2VyYm9zLnBvbGljeS52MS5QcmluY2lwYWxSdWxlLkFjdGlvbkII+kIFkgEC",
-            "CAFSB2FjdGlvbnMakgIKBkFjdGlvbhIfCgZhY3Rpb24YASABKAlCB/pCBHIC",
-            "EAFSBmFjdGlvbhI5Cgljb25kaXRpb24YAiABKAsyGy5jZXJib3MucG9saWN5",
-            "LnYxLkNvbmRpdGlvblIJY29uZGl0aW9uEjwKBmVmZmVjdBgDIAEoDjIYLmNl",
-            "cmJvcy5lZmZlY3QudjEuRWZmZWN0Qgr6QgeCAQQYARgCUgZlZmZlY3QSPAoE",
-            "bmFtZRgEIAEoCUIo+kIlciMyIV4oW1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwu",
-            "XC1dKikqJFIEbmFtZRIwCgZvdXRwdXQYBSABKAsyGC5jZXJib3MucG9saWN5",
-            "LnYxLk91dHB1dFIGb3V0cHV0IoUBCgxEZXJpdmVkUm9sZXMSLgoEbmFtZRgB",
-            "IAEoCUIa+kIXchUQATIRXltbOndvcmQ6XVwtXC5dKyRSBG5hbWUSRQoLZGVm",
-            "aW5pdGlvbnMYAiADKAsyGS5jZXJib3MucG9saWN5LnYxLlJvbGVEZWZCCPpC",
-            "BZIBAggBUgtkZWZpbml0aW9ucyK9AQoHUm9sZURlZhIsCgRuYW1lGAEgASgJ",
-            "Qhj6QhVyEzIRXltbOndvcmQ6XVwtXC5dKyRSBG5hbWUSSQoMcGFyZW50X3Jv",
-            "bGVzGAIgAygJQib6QiOSASAIARgBIhpyGDIWXihbWzp3b3JkOl1cLVwuXSt8",
-            "XCopJFILcGFyZW50Um9sZXMSOQoJY29uZGl0aW9uGAMgASgLMhsuY2VyYm9z",
-            "LnBvbGljeS52MS5Db25kaXRpb25SCWNvbmRpdGlvbiJoCglDb25kaXRpb24S",
-            "LwoFbWF0Y2gYASABKAsyFy5jZXJib3MucG9saWN5LnYxLk1hdGNoSABSBW1h",
-            "dGNoEhgKBnNjcmlwdBgCIAEoCUgAUgZzY3JpcHRCEAoJY29uZGl0aW9uEgP4",
-            "QgEiiwIKBU1hdGNoEjQKA2FsbBgBIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEu",
-            "TWF0Y2guRXhwckxpc3RIAFIDYWxsEjQKA2FueRgCIAEoCzIgLmNlcmJvcy5w",
-            "b2xpY3kudjEuTWF0Y2guRXhwckxpc3RIAFIDYW55EjYKBG5vbmUYAyABKAsy",
-            "IC5jZXJib3MucG9saWN5LnYxLk1hdGNoLkV4cHJMaXN0SABSBG5vbmUSFAoE",
-            "ZXhwchgEIAEoCUgAUgRleHByGj0KCEV4cHJMaXN0EjEKAm9mGAEgAygLMhcu",
-            "Y2VyYm9zLnBvbGljeS52MS5NYXRjaEII+kIFkgECCAFSAm9mQgkKAm9wEgP4",
-            "QgEiHAoGT3V0cHV0EhIKBGV4cHIYASABKAlSBGV4cHIixwIKB1NjaGVtYXMS",
-            "SwoQcHJpbmNpcGFsX3NjaGVtYRgBIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEu",
-            "U2NoZW1hcy5TY2hlbWFSD3ByaW5jaXBhbFNjaGVtYRJJCg9yZXNvdXJjZV9z",
-            "Y2hlbWEYAiABKAsyIC5jZXJib3MucG9saWN5LnYxLlNjaGVtYXMuU2NoZW1h",
-            "Ug5yZXNvdXJjZVNjaGVtYRo4CgpJZ25vcmVXaGVuEioKB2FjdGlvbnMYASAD",
-            "KAlCEPpCDZIBCggBGAEiBHICEAFSB2FjdGlvbnMaagoGU2NoZW1hEhkKA3Jl",
-            "ZhgBIAEoCUIH+kIEcgIQAVIDcmVmEkUKC2lnbm9yZV93aGVuGAIgASgLMiQu",
-            "Y2VyYm9zLnBvbGljeS52MS5TY2hlbWFzLklnbm9yZVdoZW5SCmlnbm9yZVdo",
-            "ZW4iwgQKC1Rlc3RGaXh0dXJlGsIBCgpQcmluY2lwYWxzElgKCnByaW5jaXBh",
-            "bHMYASADKAsyOC5jZXJib3MucG9saWN5LnYxLlRlc3RGaXh0dXJlLlByaW5j",
-            "aXBhbHMuUHJpbmNpcGFsc0VudHJ5UgpwcmluY2lwYWxzGloKD1ByaW5jaXBh",
-            "bHNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIxCgV2YWx1ZRgCIAEoCzIbLmNl",
-            "cmJvcy5lbmdpbmUudjEuUHJpbmNpcGFsUgV2YWx1ZToCOAEauwEKCVJlc291",
-            "cmNlcxJUCglyZXNvdXJjZXMYASADKAsyNi5jZXJib3MucG9saWN5LnYxLlRl",
-            "c3RGaXh0dXJlLlJlc291cmNlcy5SZXNvdXJjZXNFbnRyeVIJcmVzb3VyY2Vz",
-            "GlgKDlJlc291cmNlc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EjAKBXZhbHVl",
-            "GAIgASgLMhouY2VyYm9zLmVuZ2luZS52MS5SZXNvdXJjZVIFdmFsdWU6AjgB",
-            "Gq8BCgdBdXhEYXRhEk0KCGF1eF9kYXRhGAEgAygLMjIuY2VyYm9zLnBvbGlj",
-            "eS52MS5UZXN0Rml4dHVyZS5BdXhEYXRhLkF1eERhdGFFbnRyeVIHYXV4RGF0",
-            "YRpVCgxBdXhEYXRhRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSLwoFdmFsdWUY",
-            "AiABKAsyGS5jZXJib3MuZW5naW5lLnYxLkF1eERhdGFSBXZhbHVlOgI4ASI7",
-            "CgtUZXN0T3B0aW9ucxIsCgNub3cYASABKAsyGi5nb29nbGUucHJvdG9idWYu",
-            "VGltZXN0YW1wUgNub3ci3gUKCVRlc3RTdWl0ZRIbCgRuYW1lGAEgASgJQgf6",
-            "QgRyAhABUgRuYW1lEiAKC2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlv",
-            "bhISCgRza2lwGAMgASgIUgRza2lwEh8KC3NraXBfcmVhc29uGAQgASgJUgpz",
-            "a2lwUmVhc29uEjsKBXRlc3RzGAUgAygLMhsuY2VyYm9zLnBvbGljeS52MS5U",
-            "ZXN0VGFibGVCCPpCBZIBAggBUgV0ZXN0cxJLCgpwcmluY2lwYWxzGAYgAygL",
-            "MisuY2VyYm9zLnBvbGljeS52MS5UZXN0U3VpdGUuUHJpbmNpcGFsc0VudHJ5",
-            "UgpwcmluY2lwYWxzEkgKCXJlc291cmNlcxgHIAMoCzIqLmNlcmJvcy5wb2xp",
-            "Y3kudjEuVGVzdFN1aXRlLlJlc291cmNlc0VudHJ5UglyZXNvdXJjZXMSQwoI",
-            "YXV4X2RhdGEYCCADKAsyKC5jZXJib3MucG9saWN5LnYxLlRlc3RTdWl0ZS5B",
-            "dXhEYXRhRW50cnlSB2F1eERhdGESNwoHb3B0aW9ucxgJIAEoCzIdLmNlcmJv",
-            "cy5wb2xpY3kudjEuVGVzdE9wdGlvbnNSB29wdGlvbnMaWgoPUHJpbmNpcGFs",
-            "c0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EjEKBXZhbHVlGAIgASgLMhsuY2Vy",
-            "Ym9zLmVuZ2luZS52MS5QcmluY2lwYWxSBXZhbHVlOgI4ARpYCg5SZXNvdXJj",
-            "ZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIwCgV2YWx1ZRgCIAEoCzIaLmNl",
-            "cmJvcy5lbmdpbmUudjEuUmVzb3VyY2VSBXZhbHVlOgI4ARpVCgxBdXhEYXRh",
-            "RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSLwoFdmFsdWUYAiABKAsyGS5jZXJi",
-            "b3MuZW5naW5lLnYxLkF1eERhdGFSBXZhbHVlOgI4ASKPBgoJVGVzdFRhYmxl",
-            "EhsKBG5hbWUYASABKAlCB/pCBHICEAFSBG5hbWUSIAoLZGVzY3JpcHRpb24Y",
-            "AiABKAlSC2Rlc2NyaXB0aW9uEhIKBHNraXAYAyABKAhSBHNraXASHwoLc2tp",
-            "cF9yZWFzb24YBCABKAlSCnNraXBSZWFzb24SQQoFaW5wdXQYBSABKAsyIS5j",
-            "ZXJib3MucG9saWN5LnYxLlRlc3RUYWJsZS5JbnB1dEII+kIFigECEAFSBWlu",
-            "cHV0Ek0KCGV4cGVjdGVkGAYgAygLMicuY2VyYm9zLnBvbGljeS52MS5UZXN0",
-            "VGFibGUuRXhwZWN0YXRpb25CCPpCBZIBAggBUghleHBlY3RlZBI3CgdvcHRp",
-            "b25zGAcgASgLMh0uY2VyYm9zLnBvbGljeS52MS5UZXN0T3B0aW9uc1IHb3B0",
-            "aW9ucxqwAQoFSW5wdXQSMAoKcHJpbmNpcGFscxgBIAMoCUIQ+kINkgEKCAEY",
-            "ASIEcgIQAVIKcHJpbmNpcGFscxIuCglyZXNvdXJjZXMYAiADKAlCEPpCDZIB",
-            "CggBGAEiBHICEAFSCXJlc291cmNlcxIqCgdhY3Rpb25zGAMgAygJQhD6Qg2S",
-            "AQoIARgBIgRyAhABUgdhY3Rpb25zEhkKCGF1eF9kYXRhGAQgASgJUgdhdXhE",
-            "YXRhGo8CCgtFeHBlY3RhdGlvbhIlCglwcmluY2lwYWwYASABKAlCB/pCBHIC",
-            "EAFSCXByaW5jaXBhbBIjCghyZXNvdXJjZRgCIAEoCUIH+kIEcgIQAVIIcmVz",
-            "b3VyY2USXgoHYWN0aW9ucxgDIAMoCzI0LmNlcmJvcy5wb2xpY3kudjEuVGVz",
-            "dFRhYmxlLkV4cGVjdGF0aW9uLkFjdGlvbnNFbnRyeUIO+kILmgEICAEiBHIC",
-            "EAFSB2FjdGlvbnMaVAoMQWN0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5",
-            "Ei4KBXZhbHVlGAIgASgOMhguY2VyYm9zLmVmZmVjdC52MS5FZmZlY3RSBXZh",
-            "bHVlOgI4ASLUBAoEVGVzdBI9CgRuYW1lGAEgASgLMh8uY2VyYm9zLnBvbGlj",
-            "eS52MS5UZXN0LlRlc3ROYW1lQgj6QgWKAQIQAVIEbmFtZRIgCgtkZXNjcmlw",
-            "dGlvbhgCIAEoCVILZGVzY3JpcHRpb24SEgoEc2tpcBgDIAEoCFIEc2tpcBIf",
-            "Cgtza2lwX3JlYXNvbhgEIAEoCVIKc2tpcFJlYXNvbhI8CgVpbnB1dBgFIAEo",
-            "CzIcLmNlcmJvcy5lbmdpbmUudjEuQ2hlY2tJbnB1dEII+kIFigECEAFSBWlu",
-            "cHV0ElAKCGV4cGVjdGVkGAYgAygLMiQuY2VyYm9zLnBvbGljeS52MS5UZXN0",
-            "LkV4cGVjdGVkRW50cnlCDvpCC5oBCAgBIgRyAhABUghleHBlY3RlZBI3Cgdv",
-            "cHRpb25zGAcgASgLMh0uY2VyYm9zLnBvbGljeS52MS5UZXN0T3B0aW9uc1IH",
-            "b3B0aW9ucxqVAQoIVGVzdE5hbWUSLwoPdGVzdF90YWJsZV9uYW1lGAEgASgJ",
-            "Qgf6QgRyAhABUg10ZXN0VGFibGVOYW1lEiwKDXByaW5jaXBhbF9rZXkYAiAB",
-            "KAlCB/pCBHICEAFSDHByaW5jaXBhbEtleRIqCgxyZXNvdXJjZV9rZXkYAyAB",
-            "KAlCB/pCBHICEAFSC3Jlc291cmNlS2V5GlUKDUV4cGVjdGVkRW50cnkSEAoD",
+            "bmdpbmUvdjEvZW5naW5lLnByb3RvGhxnb29nbGUvcHJvdG9idWYvc3RydWN0",
+            "LnByb3RvGh9nb29nbGUvcHJvdG9idWYvdGltZXN0YW1wLnByb3RvGh5nb29n",
+            "bGUvcHJvdG9idWYvd3JhcHBlcnMucHJvdG8aF3ZhbGlkYXRlL3ZhbGlkYXRl",
+            "LnByb3RvIrYECgZQb2xpY3kSOQoLYXBpX3ZlcnNpb24YASABKAlCGPpCFXIT",
+            "ChFhcGkuY2VyYm9zLmRldi92MVIKYXBpVmVyc2lvbhIaCghkaXNhYmxlZBgC",
+            "IAEoCFIIZGlzYWJsZWQSIAoLZGVzY3JpcHRpb24YAyABKAlSC2Rlc2NyaXB0",
+            "aW9uEjYKCG1ldGFkYXRhGAQgASgLMhouY2VyYm9zLnBvbGljeS52MS5NZXRh",
+            "ZGF0YVIIbWV0YWRhdGESSwoPcmVzb3VyY2VfcG9saWN5GAUgASgLMiAuY2Vy",
+            "Ym9zLnBvbGljeS52MS5SZXNvdXJjZVBvbGljeUgAUg5yZXNvdXJjZVBvbGlj",
+            "eRJOChBwcmluY2lwYWxfcG9saWN5GAYgASgLMiEuY2VyYm9zLnBvbGljeS52",
+            "MS5QcmluY2lwYWxQb2xpY3lIAFIPcHJpbmNpcGFsUG9saWN5EkUKDWRlcml2",
+            "ZWRfcm9sZXMYByABKAsyHi5jZXJib3MucG9saWN5LnYxLkRlcml2ZWRSb2xl",
+            "c0gAUgxkZXJpdmVkUm9sZXMSRQoJdmFyaWFibGVzGAggAygLMicuY2VyYm9z",
+            "LnBvbGljeS52MS5Qb2xpY3kuVmFyaWFibGVzRW50cnlSCXZhcmlhYmxlcxo8",
+            "Cg5WYXJpYWJsZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgC",
+            "IAEoCVIFdmFsdWU6AjgBQhIKC3BvbGljeV90eXBlEgP4QgEixAIKCE1ldGFk",
+            "YXRhEh8KC3NvdXJjZV9maWxlGAEgASgJUgpzb3VyY2VGaWxlEk0KC2Fubm90",
+            "YXRpb25zGAIgAygLMisuY2VyYm9zLnBvbGljeS52MS5NZXRhZGF0YS5Bbm5v",
+            "dGF0aW9uc0VudHJ5Ugthbm5vdGF0aW9ucxIwCgRoYXNoGAMgASgLMhwuZ29v",
+            "Z2xlLnByb3RvYnVmLlVJbnQ2NFZhbHVlUgRoYXNoEisKD3N0b3JlX2lkZW50",
+            "aWZlchgEIAEoCUICGAFSDnN0b3JlSWRlbnRpZmVyEikKEHN0b3JlX2lkZW50",
+            "aWZpZXIYBSABKAlSD3N0b3JlSWRlbnRpZmllcho+ChBBbm5vdGF0aW9uc0Vu",
+            "dHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToC",
+            "OAEitAMKDlJlc291cmNlUG9saWN5EmYKCHJlc291cmNlGAEgASgJQkr6Qkdy",
+            "RRABMkFeW1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwuXC0vXSooXDpbWzphbHBo",
+            "YTpdXVtbOndvcmQ6XVxAXC5cLS9dKikqJFIIcmVzb3VyY2USLgoHdmVyc2lv",
+            "bhgCIAEoCUIU+kIRcg8yDV5bWzp3b3JkOl1dKyRSB3ZlcnNpb24SUQoUaW1w",
+            "b3J0X2Rlcml2ZWRfcm9sZXMYAyADKAlCH/pCHJIBGRgBIhVyEzIRXltbOndv",
+            "cmQ6XVwtXC5dKyRSEmltcG9ydERlcml2ZWRSb2xlcxI0CgVydWxlcxgEIAMo",
+            "CzIeLmNlcmJvcy5wb2xpY3kudjEuUmVzb3VyY2VSdWxlUgVydWxlcxJMCgVz",
+            "Y29wZRgFIAEoCUI2+kIzcjEyL14oW1s6YWxudW06XV1bWzp3b3JkOl1cLV0q",
+            "KFwuW1s6d29yZDpdXC1dKikqKSokUgVzY29wZRIzCgdzY2hlbWFzGAYgASgL",
+            "MhkuY2VyYm9zLnBvbGljeS52MS5TY2hlbWFzUgdzY2hlbWFzIqUDCgxSZXNv",
+            "dXJjZVJ1bGUSKgoHYWN0aW9ucxgBIAMoCUIQ+kINkgEKCAEYASIEcgIQAVIH",
+            "YWN0aW9ucxJECg1kZXJpdmVkX3JvbGVzGAIgAygJQh/6QhySARkYASIVchMy",
+            "EV5bWzp3b3JkOl1cLVwuXSskUgxkZXJpdmVkUm9sZXMSOgoFcm9sZXMYAyAD",
+            "KAlCJPpCIZIBHhgBIhpyGDIWXihbWzp3b3JkOl1cLVwuXSt8XCopJFIFcm9s",
+            "ZXMSOQoJY29uZGl0aW9uGAQgASgLMhsuY2VyYm9zLnBvbGljeS52MS5Db25k",
+            "aXRpb25SCWNvbmRpdGlvbhI8CgZlZmZlY3QYBSABKA4yGC5jZXJib3MuZWZm",
+            "ZWN0LnYxLkVmZmVjdEIK+kIHggEEGAEYAlIGZWZmZWN0EjwKBG5hbWUYBiAB",
+            "KAlCKPpCJXIjMiFeKFtbOmFscGhhOl1dW1s6d29yZDpdXEBcLlwtXSopKiRS",
+            "BG5hbWUSMAoGb3V0cHV0GAcgASgLMhguY2VyYm9zLnBvbGljeS52MS5PdXRw",
+            "dXRSBm91dHB1dCKuAgoPUHJpbmNpcGFsUG9saWN5EmYKCXByaW5jaXBhbBgB",
+            "IAEoCUJI+kJFckMQATI/XltbOmFscGhhOl1dW1s6d29yZDpdXEBcLlwtXSoo",
+            "XDpbWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5cLV0qKSokUglwcmluY2lwYWwS",
+            "LgoHdmVyc2lvbhgCIAEoCUIU+kIRcg8yDV5bWzp3b3JkOl1dKyRSB3ZlcnNp",
+            "b24SNQoFcnVsZXMYAyADKAsyHy5jZXJib3MucG9saWN5LnYxLlByaW5jaXBh",
+            "bFJ1bGVSBXJ1bGVzEkwKBXNjb3BlGAQgASgJQjb6QjNyMTIvXihbWzphbG51",
+            "bTpdXVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1cLV0qKSopKiRSBXNjb3Bl",
+            "IpUDCg1QcmluY2lwYWxSdWxlEiMKCHJlc291cmNlGAEgASgJQgf6QgRyAhAB",
+            "UghyZXNvdXJjZRJKCgdhY3Rpb25zGAIgAygLMiYuY2VyYm9zLnBvbGljeS52",
+            "MS5QcmluY2lwYWxSdWxlLkFjdGlvbkII+kIFkgECCAFSB2FjdGlvbnMakgIK",
+            "BkFjdGlvbhIfCgZhY3Rpb24YASABKAlCB/pCBHICEAFSBmFjdGlvbhI5Cglj",
+            "b25kaXRpb24YAiABKAsyGy5jZXJib3MucG9saWN5LnYxLkNvbmRpdGlvblIJ",
+            "Y29uZGl0aW9uEjwKBmVmZmVjdBgDIAEoDjIYLmNlcmJvcy5lZmZlY3QudjEu",
+            "RWZmZWN0Qgr6QgeCAQQYARgCUgZlZmZlY3QSPAoEbmFtZRgEIAEoCUIo+kIl",
+            "ciMyIV4oW1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwuXC1dKikqJFIEbmFtZRIw",
+            "CgZvdXRwdXQYBSABKAsyGC5jZXJib3MucG9saWN5LnYxLk91dHB1dFIGb3V0",
+            "cHV0IoUBCgxEZXJpdmVkUm9sZXMSLgoEbmFtZRgBIAEoCUIa+kIXchUQATIR",
+            "XltbOndvcmQ6XVwtXC5dKyRSBG5hbWUSRQoLZGVmaW5pdGlvbnMYAiADKAsy",
+            "GS5jZXJib3MucG9saWN5LnYxLlJvbGVEZWZCCPpCBZIBAggBUgtkZWZpbml0",
+            "aW9ucyK9AQoHUm9sZURlZhIsCgRuYW1lGAEgASgJQhj6QhVyEzIRXltbOndv",
+            "cmQ6XVwtXC5dKyRSBG5hbWUSSQoMcGFyZW50X3JvbGVzGAIgAygJQib6QiOS",
+            "ASAIARgBIhpyGDIWXihbWzp3b3JkOl1cLVwuXSt8XCopJFILcGFyZW50Um9s",
+            "ZXMSOQoJY29uZGl0aW9uGAMgASgLMhsuY2VyYm9zLnBvbGljeS52MS5Db25k",
+            "aXRpb25SCWNvbmRpdGlvbiJoCglDb25kaXRpb24SLwoFbWF0Y2gYASABKAsy",
+            "Fy5jZXJib3MucG9saWN5LnYxLk1hdGNoSABSBW1hdGNoEhgKBnNjcmlwdBgC",
+            "IAEoCUgAUgZzY3JpcHRCEAoJY29uZGl0aW9uEgP4QgEiiwIKBU1hdGNoEjQK",
+            "A2FsbBgBIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEuTWF0Y2guRXhwckxpc3RI",
+            "AFIDYWxsEjQKA2FueRgCIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEuTWF0Y2gu",
+            "RXhwckxpc3RIAFIDYW55EjYKBG5vbmUYAyABKAsyIC5jZXJib3MucG9saWN5",
+            "LnYxLk1hdGNoLkV4cHJMaXN0SABSBG5vbmUSFAoEZXhwchgEIAEoCUgAUgRl",
+            "eHByGj0KCEV4cHJMaXN0EjEKAm9mGAEgAygLMhcuY2VyYm9zLnBvbGljeS52",
+            "MS5NYXRjaEII+kIFkgECCAFSAm9mQgkKAm9wEgP4QgEiHAoGT3V0cHV0EhIK",
+            "BGV4cHIYASABKAlSBGV4cHIixwIKB1NjaGVtYXMSSwoQcHJpbmNpcGFsX3Nj",
+            "aGVtYRgBIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEuU2NoZW1hcy5TY2hlbWFS",
+            "D3ByaW5jaXBhbFNjaGVtYRJJCg9yZXNvdXJjZV9zY2hlbWEYAiABKAsyIC5j",
+            "ZXJib3MucG9saWN5LnYxLlNjaGVtYXMuU2NoZW1hUg5yZXNvdXJjZVNjaGVt",
+            "YRo4CgpJZ25vcmVXaGVuEioKB2FjdGlvbnMYASADKAlCEPpCDZIBCggBGAEi",
+            "BHICEAFSB2FjdGlvbnMaagoGU2NoZW1hEhkKA3JlZhgBIAEoCUIH+kIEcgIQ",
+            "AVIDcmVmEkUKC2lnbm9yZV93aGVuGAIgASgLMiQuY2VyYm9zLnBvbGljeS52",
+            "MS5TY2hlbWFzLklnbm9yZVdoZW5SCmlnbm9yZVdoZW4iwgQKC1Rlc3RGaXh0",
+            "dXJlGsIBCgpQcmluY2lwYWxzElgKCnByaW5jaXBhbHMYASADKAsyOC5jZXJi",
+            "b3MucG9saWN5LnYxLlRlc3RGaXh0dXJlLlByaW5jaXBhbHMuUHJpbmNpcGFs",
+            "c0VudHJ5UgpwcmluY2lwYWxzGloKD1ByaW5jaXBhbHNFbnRyeRIQCgNrZXkY",
+            "ASABKAlSA2tleRIxCgV2YWx1ZRgCIAEoCzIbLmNlcmJvcy5lbmdpbmUudjEu",
+            "UHJpbmNpcGFsUgV2YWx1ZToCOAEauwEKCVJlc291cmNlcxJUCglyZXNvdXJj",
+            "ZXMYASADKAsyNi5jZXJib3MucG9saWN5LnYxLlRlc3RGaXh0dXJlLlJlc291",
+            "cmNlcy5SZXNvdXJjZXNFbnRyeVIJcmVzb3VyY2VzGlgKDlJlc291cmNlc0Vu",
+            "dHJ5EhAKA2tleRgBIAEoCVIDa2V5EjAKBXZhbHVlGAIgASgLMhouY2VyYm9z",
+            "LmVuZ2luZS52MS5SZXNvdXJjZVIFdmFsdWU6AjgBGq8BCgdBdXhEYXRhEk0K",
+            "CGF1eF9kYXRhGAEgAygLMjIuY2VyYm9zLnBvbGljeS52MS5UZXN0Rml4dHVy",
+            "ZS5BdXhEYXRhLkF1eERhdGFFbnRyeVIHYXV4RGF0YRpVCgxBdXhEYXRhRW50",
+            "cnkSEAoDa2V5GAEgASgJUgNrZXkSLwoFdmFsdWUYAiABKAsyGS5jZXJib3Mu",
+            "ZW5naW5lLnYxLkF1eERhdGFSBXZhbHVlOgI4ASI7CgtUZXN0T3B0aW9ucxIs",
+            "CgNub3cYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgNub3ci",
+            "3gUKCVRlc3RTdWl0ZRIbCgRuYW1lGAEgASgJQgf6QgRyAhABUgRuYW1lEiAK",
+            "C2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlvbhISCgRza2lwGAMgASgI",
+            "UgRza2lwEh8KC3NraXBfcmVhc29uGAQgASgJUgpza2lwUmVhc29uEjsKBXRl",
+            "c3RzGAUgAygLMhsuY2VyYm9zLnBvbGljeS52MS5UZXN0VGFibGVCCPpCBZIB",
+            "AggBUgV0ZXN0cxJLCgpwcmluY2lwYWxzGAYgAygLMisuY2VyYm9zLnBvbGlj",
+            "eS52MS5UZXN0U3VpdGUuUHJpbmNpcGFsc0VudHJ5UgpwcmluY2lwYWxzEkgK",
+            "CXJlc291cmNlcxgHIAMoCzIqLmNlcmJvcy5wb2xpY3kudjEuVGVzdFN1aXRl",
+            "LlJlc291cmNlc0VudHJ5UglyZXNvdXJjZXMSQwoIYXV4X2RhdGEYCCADKAsy",
+            "KC5jZXJib3MucG9saWN5LnYxLlRlc3RTdWl0ZS5BdXhEYXRhRW50cnlSB2F1",
+            "eERhdGESNwoHb3B0aW9ucxgJIAEoCzIdLmNlcmJvcy5wb2xpY3kudjEuVGVz",
+            "dE9wdGlvbnNSB29wdGlvbnMaWgoPUHJpbmNpcGFsc0VudHJ5EhAKA2tleRgB",
+            "IAEoCVIDa2V5EjEKBXZhbHVlGAIgASgLMhsuY2VyYm9zLmVuZ2luZS52MS5Q",
+            "cmluY2lwYWxSBXZhbHVlOgI4ARpYCg5SZXNvdXJjZXNFbnRyeRIQCgNrZXkY",
+            "ASABKAlSA2tleRIwCgV2YWx1ZRgCIAEoCzIaLmNlcmJvcy5lbmdpbmUudjEu",
+            "UmVzb3VyY2VSBXZhbHVlOgI4ARpVCgxBdXhEYXRhRW50cnkSEAoDa2V5GAEg",
+            "ASgJUgNrZXkSLwoFdmFsdWUYAiABKAsyGS5jZXJib3MuZW5naW5lLnYxLkF1",
+            "eERhdGFSBXZhbHVlOgI4ASLVBwoJVGVzdFRhYmxlEhsKBG5hbWUYASABKAlC",
+            "B/pCBHICEAFSBG5hbWUSIAoLZGVzY3JpcHRpb24YAiABKAlSC2Rlc2NyaXB0",
+            "aW9uEhIKBHNraXAYAyABKAhSBHNraXASHwoLc2tpcF9yZWFzb24YBCABKAlS",
+            "CnNraXBSZWFzb24SQQoFaW5wdXQYBSABKAsyIS5jZXJib3MucG9saWN5LnYx",
+            "LlRlc3RUYWJsZS5JbnB1dEII+kIFigECEAFSBWlucHV0Ek0KCGV4cGVjdGVk",
+            "GAYgAygLMicuY2VyYm9zLnBvbGljeS52MS5UZXN0VGFibGUuRXhwZWN0YXRp",
+            "b25CCPpCBZIBAggBUghleHBlY3RlZBI3CgdvcHRpb25zGAcgASgLMh0uY2Vy",
+            "Ym9zLnBvbGljeS52MS5UZXN0T3B0aW9uc1IHb3B0aW9ucxqwAQoFSW5wdXQS",
+            "MAoKcHJpbmNpcGFscxgBIAMoCUIQ+kINkgEKCAEYASIEcgIQAVIKcHJpbmNp",
+            "cGFscxIuCglyZXNvdXJjZXMYAiADKAlCEPpCDZIBCggBGAEiBHICEAFSCXJl",
+            "c291cmNlcxIqCgdhY3Rpb25zGAMgAygJQhD6Qg2SAQoIARgBIgRyAhABUgdh",
+            "Y3Rpb25zEhkKCGF1eF9kYXRhGAQgASgJUgdhdXhEYXRhGnoKEk91dHB1dEV4",
+            "cGVjdGF0aW9ucxIfCgZhY3Rpb24YASABKAlCB/pCBHICEAFSBmFjdGlvbhJD",
+            "CghleHBlY3RlZBgCIAMoCzIdLmNlcmJvcy5lbmdpbmUudjEuT3V0cHV0RW50",
+            "cnlCCPpCBZIBAggBUghleHBlY3RlZBrZAgoLRXhwZWN0YXRpb24SJQoJcHJp",
+            "bmNpcGFsGAEgASgJQgf6QgRyAhABUglwcmluY2lwYWwSIwoIcmVzb3VyY2UY",
+            "AiABKAlCB/pCBHICEAFSCHJlc291cmNlEl4KB2FjdGlvbnMYAyADKAsyNC5j",
+            "ZXJib3MucG9saWN5LnYxLlRlc3RUYWJsZS5FeHBlY3RhdGlvbi5BY3Rpb25z",
+            "RW50cnlCDvpCC5oBCAgBIgRyAhABUgdhY3Rpb25zEkgKB291dHB1dHMYBCAD",
+            "KAsyLi5jZXJib3MucG9saWN5LnYxLlRlc3RUYWJsZS5PdXRwdXRFeHBlY3Rh",
+            "dGlvbnNSB291dHB1dHMaVAoMQWN0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVID",
+            "a2V5Ei4KBXZhbHVlGAIgASgOMhguY2VyYm9zLmVmZmVjdC52MS5FZmZlY3RS",
+            "BXZhbHVlOgI4ASLJBwoEVGVzdBI9CgRuYW1lGAEgASgLMh8uY2VyYm9zLnBv",
+            "bGljeS52MS5UZXN0LlRlc3ROYW1lQgj6QgWKAQIQAVIEbmFtZRIgCgtkZXNj",
+            "cmlwdGlvbhgCIAEoCVILZGVzY3JpcHRpb24SEgoEc2tpcBgDIAEoCFIEc2tp",
+            "cBIfCgtza2lwX3JlYXNvbhgEIAEoCVIKc2tpcFJlYXNvbhI8CgVpbnB1dBgF",
+            "IAEoCzIcLmNlcmJvcy5lbmdpbmUudjEuQ2hlY2tJbnB1dEII+kIFigECEAFS",
+            "BWlucHV0ElAKCGV4cGVjdGVkGAYgAygLMiQuY2VyYm9zLnBvbGljeS52MS5U",
+            "ZXN0LkV4cGVjdGVkRW50cnlCDvpCC5oBCAgBIgRyAhABUghleHBlY3RlZBI3",
+            "CgdvcHRpb25zGAcgASgLMh0uY2VyYm9zLnBvbGljeS52MS5UZXN0T3B0aW9u",
+            "c1IHb3B0aW9ucxJWChBleHBlY3RlZF9vdXRwdXRzGAggAygLMisuY2VyYm9z",
+            "LnBvbGljeS52MS5UZXN0LkV4cGVjdGVkT3V0cHV0c0VudHJ5Ug9leHBlY3Rl",
+            "ZE91dHB1dHMalQEKCFRlc3ROYW1lEi8KD3Rlc3RfdGFibGVfbmFtZRgBIAEo",
+            "CUIH+kIEcgIQAVINdGVzdFRhYmxlTmFtZRIsCg1wcmluY2lwYWxfa2V5GAIg",
+            "ASgJQgf6QgRyAhABUgxwcmluY2lwYWxLZXkSKgoMcmVzb3VyY2Vfa2V5GAMg",
+            "ASgJQgf6QgRyAhABUgtyZXNvdXJjZUtleRqwAQoNT3V0cHV0RW50cmllcxJL",
+            "CgdlbnRyaWVzGAEgAygLMjEuY2VyYm9zLnBvbGljeS52MS5UZXN0Lk91dHB1",
+            "dEVudHJpZXMuRW50cmllc0VudHJ5UgdlbnRyaWVzGlIKDEVudHJpZXNFbnRy",
+            "eRIQCgNrZXkYASABKAlSA2tleRIsCgV2YWx1ZRgCIAEoCzIWLmdvb2dsZS5w",
+            "cm90b2J1Zi5WYWx1ZVIFdmFsdWU6AjgBGlUKDUV4cGVjdGVkRW50cnkSEAoD",
             "a2V5GAEgASgJUgNrZXkSLgoFdmFsdWUYAiABKA4yGC5jZXJib3MuZWZmZWN0",
-            "LnYxLkVmZmVjdFIFdmFsdWU6AjgBIskMCgtUZXN0UmVzdWx0cxI7CgZzdWl0",
-            "ZXMYASADKAsyIy5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlN1aXRl",
-            "UgZzdWl0ZXMSPwoHc3VtbWFyeRgCIAEoCzIlLmNlcmJvcy5wb2xpY3kudjEu",
-            "VGVzdFJlc3VsdHMuU3VtbWFyeVIHc3VtbWFyeRpbCgVUYWxseRI8CgZyZXN1",
-            "bHQYASABKA4yJC5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlJlc3Vs",
-            "dFIGcmVzdWx0EhQKBWNvdW50GAIgASgNUgVjb3VudBrBAQoHU3VtbWFyeRJL",
-            "Cg5vdmVyYWxsX3Jlc3VsdBgBIAEoDjIkLmNlcmJvcy5wb2xpY3kudjEuVGVz",
-            "dFJlc3VsdHMuUmVzdWx0Ug1vdmVyYWxsUmVzdWx0Eh8KC3Rlc3RzX2NvdW50",
-            "GAIgASgNUgp0ZXN0c0NvdW50EkgKDXJlc3VsdF9jb3VudHMYAyADKAsyIy5j",
-            "ZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlRhbGx5UgxyZXN1bHRDb3Vu",
-            "dHMavAIKBVN1aXRlEhIKBGZpbGUYASABKAlSBGZpbGUSEgoEbmFtZRgCIAEo",
-            "CVIEbmFtZRJLCgpwcmluY2lwYWxzGAMgAygLMicuY2VyYm9zLnBvbGljeS52",
-            "MS5UZXN0UmVzdWx0cy5QcmluY2lwYWxCAhgBUgpwcmluY2lwYWxzEj8KB3N1",
-            "bW1hcnkYBCABKAsyJS5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlN1",
-            "bW1hcnlSB3N1bW1hcnkSFAoFZXJyb3IYBSABKAlSBWVycm9yEkUKCnRlc3Rf",
-            "Y2FzZXMYBiADKAsyJi5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlRl",
-            "c3RDYXNlUgl0ZXN0Q2FzZXMSIAoLZGVzY3JpcHRpb24YByABKAlSC2Rlc2Ny",
-            "aXB0aW9uGmcKCFRlc3RDYXNlEhIKBG5hbWUYASABKAlSBG5hbWUSRwoKcHJp",
-            "bmNpcGFscxgCIAMoCzInLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMu",
-            "UHJpbmNpcGFsUgpwcmluY2lwYWxzGmUKCVByaW5jaXBhbBISCgRuYW1lGAEg",
-            "ASgJUgRuYW1lEkQKCXJlc291cmNlcxgCIAMoCzImLmNlcmJvcy5wb2xpY3ku",
-            "djEuVGVzdFJlc3VsdHMuUmVzb3VyY2VSCXJlc291cmNlcxpeCghSZXNvdXJj",
-            "ZRISCgRuYW1lGAEgASgJUgRuYW1lEj4KB2FjdGlvbnMYAiADKAsyJC5jZXJi",
-            "b3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLkFjdGlvblIHYWN0aW9ucxpdCgZB",
-            "Y3Rpb24SEgoEbmFtZRgBIAEoCVIEbmFtZRI/CgdkZXRhaWxzGAIgASgLMiUu",
-            "Y2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0cy5EZXRhaWxzUgdkZXRhaWxz",
-            "GukBCgdEZXRhaWxzEjwKBnJlc3VsdBgBIAEoDjIkLmNlcmJvcy5wb2xpY3ku",
-            "djEuVGVzdFJlc3VsdHMuUmVzdWx0UgZyZXN1bHQSQQoHZmFpbHVyZRgCIAEo",
-            "CzIlLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMuRmFpbHVyZUgAUgdm",
-            "YWlsdXJlEhYKBWVycm9yGAMgASgJSABSBWVycm9yEjoKDGVuZ2luZV90cmFj",
-            "ZRgEIAMoCzIXLmNlcmJvcy5lbmdpbmUudjEuVHJhY2VSC2VuZ2luZVRyYWNl",
-            "QgkKB291dGNvbWUacQoHRmFpbHVyZRI0CghleHBlY3RlZBgBIAEoDjIYLmNl",
-            "cmJvcy5lZmZlY3QudjEuRWZmZWN0UghleHBlY3RlZBIwCgZhY3R1YWwYAiAB",
-            "KA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVjdFIGYWN0dWFsIm4KBlJlc3Vs",
-            "dBIWChJSRVNVTFRfVU5TUEVDSUZJRUQQABISCg5SRVNVTFRfU0tJUFBFRBAB",
-            "EhEKDVJFU1VMVF9QQVNTRUQQAhIRCg1SRVNVTFRfRkFJTEVEEAMSEgoOUkVT",
-            "VUxUX0VSUk9SRUQQBEJvChhkZXYuY2VyYm9zLmFwaS52MS5wb2xpY3laPGdp",
-            "dGh1Yi5jb20vY2VyYm9zL2NlcmJvcy9hcGkvZ2VucGIvY2VyYm9zL3BvbGlj",
-            "eS92MTtwb2xpY3l2MaoCFENlcmJvcy5BcGkuVjEuUG9saWN5YgZwcm90bzM="));
+            "LnYxLkVmZmVjdFIFdmFsdWU6AjgBGmgKFEV4cGVjdGVkT3V0cHV0c0VudHJ5",
+            "EhAKA2tleRgBIAEoCVIDa2V5EjoKBXZhbHVlGAIgASgLMiQuY2VyYm9zLnBv",
+            "bGljeS52MS5UZXN0Lk91dHB1dEVudHJpZXNSBXZhbHVlOgI4ASKwEAoLVGVz",
+            "dFJlc3VsdHMSOwoGc3VpdGVzGAEgAygLMiMuY2VyYm9zLnBvbGljeS52MS5U",
+            "ZXN0UmVzdWx0cy5TdWl0ZVIGc3VpdGVzEj8KB3N1bW1hcnkYAiABKAsyJS5j",
+            "ZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlN1bW1hcnlSB3N1bW1hcnka",
+            "WwoFVGFsbHkSPAoGcmVzdWx0GAEgASgOMiQuY2VyYm9zLnBvbGljeS52MS5U",
+            "ZXN0UmVzdWx0cy5SZXN1bHRSBnJlc3VsdBIUCgVjb3VudBgCIAEoDVIFY291",
+            "bnQawQEKB1N1bW1hcnkSSwoOb3ZlcmFsbF9yZXN1bHQYASABKA4yJC5jZXJi",
+            "b3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlJlc3VsdFINb3ZlcmFsbFJlc3Vs",
+            "dBIfCgt0ZXN0c19jb3VudBgCIAEoDVIKdGVzdHNDb3VudBJICg1yZXN1bHRf",
+            "Y291bnRzGAMgAygLMiMuY2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0cy5U",
+            "YWxseVIMcmVzdWx0Q291bnRzGrwCCgVTdWl0ZRISCgRmaWxlGAEgASgJUgRm",
+            "aWxlEhIKBG5hbWUYAiABKAlSBG5hbWUSSwoKcHJpbmNpcGFscxgDIAMoCzIn",
+            "LmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMuUHJpbmNpcGFsQgIYAVIK",
+            "cHJpbmNpcGFscxI/CgdzdW1tYXJ5GAQgASgLMiUuY2VyYm9zLnBvbGljeS52",
+            "MS5UZXN0UmVzdWx0cy5TdW1tYXJ5UgdzdW1tYXJ5EhQKBWVycm9yGAUgASgJ",
+            "UgVlcnJvchJFCgp0ZXN0X2Nhc2VzGAYgAygLMiYuY2VyYm9zLnBvbGljeS52",
+            "MS5UZXN0UmVzdWx0cy5UZXN0Q2FzZVIJdGVzdENhc2VzEiAKC2Rlc2NyaXB0",
+            "aW9uGAcgASgJUgtkZXNjcmlwdGlvbhpnCghUZXN0Q2FzZRISCgRuYW1lGAEg",
+            "ASgJUgRuYW1lEkcKCnByaW5jaXBhbHMYAiADKAsyJy5jZXJib3MucG9saWN5",
+            "LnYxLlRlc3RSZXN1bHRzLlByaW5jaXBhbFIKcHJpbmNpcGFscxplCglQcmlu",
+            "Y2lwYWwSEgoEbmFtZRgBIAEoCVIEbmFtZRJECglyZXNvdXJjZXMYAiADKAsy",
+            "Ji5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlJlc291cmNlUglyZXNv",
+            "dXJjZXMaXgoIUmVzb3VyY2USEgoEbmFtZRgBIAEoCVIEbmFtZRI+CgdhY3Rp",
+            "b25zGAIgAygLMiQuY2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0cy5BY3Rp",
+            "b25SB2FjdGlvbnMaXQoGQWN0aW9uEhIKBG5hbWUYASABKAlSBG5hbWUSPwoH",
+            "ZGV0YWlscxgCIAEoCzIlLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMu",
+            "RGV0YWlsc1IHZGV0YWlscxrpAQoHRGV0YWlscxI8CgZyZXN1bHQYASABKA4y",
+            "JC5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlJlc3VsdFIGcmVzdWx0",
+            "EkEKB2ZhaWx1cmUYAiABKAsyJS5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1",
+            "bHRzLkZhaWx1cmVIAFIHZmFpbHVyZRIWCgVlcnJvchgDIAEoCUgAUgVlcnJv",
+            "chI6CgxlbmdpbmVfdHJhY2UYBCADKAsyFy5jZXJib3MuZW5naW5lLnYxLlRy",
+            "YWNlUgtlbmdpbmVUcmFjZUIJCgdvdXRjb21lGpwDCg1PdXRwdXRGYWlsdXJl",
+            "EhAKA3NyYxgBIAEoCVIDc3JjEl0KCm1pc21hdGNoZWQYAiABKAsyOy5jZXJi",
+            "b3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLk91dHB1dEZhaWx1cmUuTWlzbWF0",
+            "Y2hlZFZhbHVlSABSCm1pc21hdGNoZWQSVAoHbWlzc2luZxgDIAEoCzI4LmNl",
+            "cmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMuT3V0cHV0RmFpbHVyZS5NaXNz",
+            "aW5nVmFsdWVIAFIHbWlzc2luZxp1Cg9NaXNtYXRjaGVkVmFsdWUSMgoIZXhw",
+            "ZWN0ZWQYASABKAsyFi5nb29nbGUucHJvdG9idWYuVmFsdWVSCGV4cGVjdGVk",
+            "Ei4KBmFjdHVhbBgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZVIGYWN0",
+            "dWFsGkIKDE1pc3NpbmdWYWx1ZRIyCghleHBlY3RlZBgBIAEoCzIWLmdvb2ds",
+            "ZS5wcm90b2J1Zi5WYWx1ZVIIZXhwZWN0ZWRCCQoHb3V0Y29tZRq4AQoHRmFp",
+            "bHVyZRI0CghleHBlY3RlZBgBIAEoDjIYLmNlcmJvcy5lZmZlY3QudjEuRWZm",
+            "ZWN0UghleHBlY3RlZBIwCgZhY3R1YWwYAiABKA4yGC5jZXJib3MuZWZmZWN0",
+            "LnYxLkVmZmVjdFIGYWN0dWFsEkUKB291dHB1dHMYAyADKAsyKy5jZXJib3Mu",
+            "cG9saWN5LnYxLlRlc3RSZXN1bHRzLk91dHB1dEZhaWx1cmVSB291dHB1dHMi",
+            "bgoGUmVzdWx0EhYKElJFU1VMVF9VTlNQRUNJRklFRBAAEhIKDlJFU1VMVF9T",
+            "S0lQUEVEEAESEQoNUkVTVUxUX1BBU1NFRBACEhEKDVJFU1VMVF9GQUlMRUQQ",
+            "AxISCg5SRVNVTFRfRVJST1JFRBAEQm8KGGRldi5jZXJib3MuYXBpLnYxLnBv",
+            "bGljeVo8Z2l0aHViLmNvbS9jZXJib3MvY2VyYm9zL2FwaS9nZW5wYi9jZXJi",
+            "b3MvcG9saWN5L3YxO3BvbGljeXYxqgIUQ2VyYm9zLkFwaS5WMS5Qb2xpY3li",
+            "BnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Effect.EffectReflection.Descriptor, global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.WrappersReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Effect.EffectReflection.Descriptor, global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.WrappersReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Policy), global::Cerbos.Api.V1.Policy.Policy.Parser, new[]{ "ApiVersion", "Disabled", "Description", "Metadata", "ResourcePolicy", "PrincipalPolicy", "DerivedRoles", "Variables" }, new[]{ "PolicyType" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Metadata), global::Cerbos.Api.V1.Policy.Metadata.Parser, new[]{ "SourceFile", "Annotations", "Hash", "StoreIdentifer", "StoreIdentifier" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
@@ -229,9 +254,11 @@ namespace Cerbos.Api.V1.Policy {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestOptions), global::Cerbos.Api.V1.Policy.TestOptions.Parser, new[]{ "Now" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestSuite), global::Cerbos.Api.V1.Policy.TestSuite.Parser, new[]{ "Name", "Description", "Skip", "SkipReason", "Tests", "Principals", "Resources", "AuxData", "Options" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestTable), global::Cerbos.Api.V1.Policy.TestTable.Parser, new[]{ "Name", "Description", "Skip", "SkipReason", "Input", "Expected", "Options" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestTable.Types.Input), global::Cerbos.Api.V1.Policy.TestTable.Types.Input.Parser, new[]{ "Principals", "Resources", "Actions", "AuxData" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestTable.Types.Expectation), global::Cerbos.Api.V1.Policy.TestTable.Types.Expectation.Parser, new[]{ "Principal", "Resource", "Actions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, })}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Test), global::Cerbos.Api.V1.Policy.Test.Parser, new[]{ "Name", "Description", "Skip", "SkipReason", "Input", "Expected", "Options" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Test.Types.TestName), global::Cerbos.Api.V1.Policy.Test.Types.TestName.Parser, new[]{ "TestTableName", "PrincipalKey", "ResourceKey" }, null, null, null, null),
-            null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations), global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations.Parser, new[]{ "Action", "Expected" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestTable.Types.Expectation), global::Cerbos.Api.V1.Policy.TestTable.Types.Expectation.Parser, new[]{ "Principal", "Resource", "Actions", "Outputs" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, })}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Test), global::Cerbos.Api.V1.Policy.Test.Parser, new[]{ "Name", "Description", "Skip", "SkipReason", "Input", "Expected", "Options", "ExpectedOutputs" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Test.Types.TestName), global::Cerbos.Api.V1.Policy.Test.Types.TestName.Parser, new[]{ "TestTableName", "PrincipalKey", "ResourceKey" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries), global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries.Parser, new[]{ "Entries" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
+            null, null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults), global::Cerbos.Api.V1.Policy.TestResults.Parser, new[]{ "Suites", "Summary" }, null, new[]{ typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Result) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Tally), global::Cerbos.Api.V1.Policy.TestResults.Types.Tally.Parser, new[]{ "Result", "Count" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Summary), global::Cerbos.Api.V1.Policy.TestResults.Types.Summary.Parser, new[]{ "OverallResult", "TestsCount", "ResultCounts" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Suite), global::Cerbos.Api.V1.Policy.TestResults.Types.Suite.Parser, new[]{ "File", "Name", "Principals", "Summary", "Error", "TestCases", "Description" }, null, null, null, null),
@@ -240,7 +267,9 @@ namespace Cerbos.Api.V1.Policy {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Resource), global::Cerbos.Api.V1.Policy.TestResults.Types.Resource.Parser, new[]{ "Name", "Actions" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Action), global::Cerbos.Api.V1.Policy.TestResults.Types.Action.Parser, new[]{ "Name", "Details" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Details), global::Cerbos.Api.V1.Policy.TestResults.Types.Details.Parser, new[]{ "Result", "Failure", "Error", "EngineTrace" }, new[]{ "Outcome" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Failure), global::Cerbos.Api.V1.Policy.TestResults.Types.Failure.Parser, new[]{ "Expected", "Actual" }, null, null, null, null)})
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure), global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Parser, new[]{ "Src", "Mismatched", "Missing" }, new[]{ "Outcome" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue), global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue.Parser, new[]{ "Expected", "Actual" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue), global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue.Parser, new[]{ "Expected" }, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestResults.Types.Failure), global::Cerbos.Api.V1.Policy.TestResults.Types.Failure.Parser, new[]{ "Expected", "Actual", "Outputs" }, null, null, null, null)})
           }));
     }
     #endregion
@@ -6951,6 +6980,221 @@ namespace Cerbos.Api.V1.Policy {
 
       }
 
+      public sealed partial class OutputExpectations : pb::IMessage<OutputExpectations>
+      #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          , pb::IBufferMessage
+      #endif
+      {
+        private static readonly pb::MessageParser<OutputExpectations> _parser = new pb::MessageParser<OutputExpectations>(() => new OutputExpectations());
+        private pb::UnknownFieldSet _unknownFields;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static pb::MessageParser<OutputExpectations> Parser { get { return _parser; } }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static pbr::MessageDescriptor Descriptor {
+          get { return global::Cerbos.Api.V1.Policy.TestTable.Descriptor.NestedTypes[1]; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        pbr::MessageDescriptor pb::IMessage.Descriptor {
+          get { return Descriptor; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputExpectations() {
+          OnConstruction();
+        }
+
+        partial void OnConstruction();
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputExpectations(OutputExpectations other) : this() {
+          action_ = other.action_;
+          expected_ = other.expected_.Clone();
+          _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputExpectations Clone() {
+          return new OutputExpectations(this);
+        }
+
+        /// <summary>Field number for the "action" field.</summary>
+        public const int ActionFieldNumber = 1;
+        private string action_ = "";
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public string Action {
+          get { return action_; }
+          set {
+            action_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+          }
+        }
+
+        /// <summary>Field number for the "expected" field.</summary>
+        public const int ExpectedFieldNumber = 2;
+        private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Engine.OutputEntry> _repeated_expected_codec
+            = pb::FieldCodec.ForMessage(18, global::Cerbos.Api.V1.Engine.OutputEntry.Parser);
+        private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> expected_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> Expected {
+          get { return expected_; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override bool Equals(object other) {
+          return Equals(other as OutputExpectations);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool Equals(OutputExpectations other) {
+          if (ReferenceEquals(other, null)) {
+            return false;
+          }
+          if (ReferenceEquals(other, this)) {
+            return true;
+          }
+          if (Action != other.Action) return false;
+          if(!expected_.Equals(other.expected_)) return false;
+          return Equals(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override int GetHashCode() {
+          int hash = 1;
+          if (Action.Length != 0) hash ^= Action.GetHashCode();
+          hash ^= expected_.GetHashCode();
+          if (_unknownFields != null) {
+            hash ^= _unknownFields.GetHashCode();
+          }
+          return hash;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override string ToString() {
+          return pb::JsonFormatter.ToDiagnosticString(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void WriteTo(pb::CodedOutputStream output) {
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          output.WriteRawMessage(this);
+        #else
+          if (Action.Length != 0) {
+            output.WriteRawTag(10);
+            output.WriteString(Action);
+          }
+          expected_.WriteTo(output, _repeated_expected_codec);
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(output);
+          }
+        #endif
+        }
+
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+          if (Action.Length != 0) {
+            output.WriteRawTag(10);
+            output.WriteString(Action);
+          }
+          expected_.WriteTo(ref output, _repeated_expected_codec);
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(ref output);
+          }
+        }
+        #endif
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public int CalculateSize() {
+          int size = 0;
+          if (Action.Length != 0) {
+            size += 1 + pb::CodedOutputStream.ComputeStringSize(Action);
+          }
+          size += expected_.CalculateSize(_repeated_expected_codec);
+          if (_unknownFields != null) {
+            size += _unknownFields.CalculateSize();
+          }
+          return size;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void MergeFrom(OutputExpectations other) {
+          if (other == null) {
+            return;
+          }
+          if (other.Action.Length != 0) {
+            Action = other.Action;
+          }
+          expected_.Add(other.expected_);
+          _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void MergeFrom(pb::CodedInputStream input) {
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          input.ReadRawMessage(this);
+        #else
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                break;
+              case 10: {
+                Action = input.ReadString();
+                break;
+              }
+              case 18: {
+                expected_.AddEntriesFrom(input, _repeated_expected_codec);
+                break;
+              }
+            }
+          }
+        #endif
+        }
+
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                break;
+              case 10: {
+                Action = input.ReadString();
+                break;
+              }
+              case 18: {
+                expected_.AddEntriesFrom(ref input, _repeated_expected_codec);
+                break;
+              }
+            }
+          }
+        }
+        #endif
+
+      }
+
       public sealed partial class Expectation : pb::IMessage<Expectation>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage
@@ -6965,7 +7209,7 @@ namespace Cerbos.Api.V1.Policy {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::Cerbos.Api.V1.Policy.TestTable.Descriptor.NestedTypes[1]; }
+          get { return global::Cerbos.Api.V1.Policy.TestTable.Descriptor.NestedTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6988,6 +7232,7 @@ namespace Cerbos.Api.V1.Policy {
           principal_ = other.principal_;
           resource_ = other.resource_;
           actions_ = other.actions_.Clone();
+          outputs_ = other.outputs_.Clone();
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -7032,6 +7277,17 @@ namespace Cerbos.Api.V1.Policy {
           get { return actions_; }
         }
 
+        /// <summary>Field number for the "outputs" field.</summary>
+        public const int OutputsFieldNumber = 4;
+        private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations> _repeated_outputs_codec
+            = pb::FieldCodec.ForMessage(34, global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations.Parser);
+        private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations> outputs_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<global::Cerbos.Api.V1.Policy.TestTable.Types.OutputExpectations> Outputs {
+          get { return outputs_; }
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -7050,6 +7306,7 @@ namespace Cerbos.Api.V1.Policy {
           if (Principal != other.Principal) return false;
           if (Resource != other.Resource) return false;
           if (!Actions.Equals(other.Actions)) return false;
+          if(!outputs_.Equals(other.outputs_)) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -7060,6 +7317,7 @@ namespace Cerbos.Api.V1.Policy {
           if (Principal.Length != 0) hash ^= Principal.GetHashCode();
           if (Resource.Length != 0) hash ^= Resource.GetHashCode();
           hash ^= Actions.GetHashCode();
+          hash ^= outputs_.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -7087,6 +7345,7 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteString(Resource);
           }
           actions_.WriteTo(output, _map_actions_codec);
+          outputs_.WriteTo(output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -7106,6 +7365,7 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteString(Resource);
           }
           actions_.WriteTo(ref output, _map_actions_codec);
+          outputs_.WriteTo(ref output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -7123,6 +7383,7 @@ namespace Cerbos.Api.V1.Policy {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Resource);
           }
           size += actions_.CalculateSize(_map_actions_codec);
+          size += outputs_.CalculateSize(_repeated_outputs_codec);
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
           }
@@ -7142,6 +7403,7 @@ namespace Cerbos.Api.V1.Policy {
             Resource = other.Resource;
           }
           actions_.MergeFrom(other.actions_);
+          outputs_.Add(other.outputs_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -7169,6 +7431,10 @@ namespace Cerbos.Api.V1.Policy {
                 actions_.AddEntriesFrom(input, _map_actions_codec);
                 break;
               }
+              case 34: {
+                outputs_.AddEntriesFrom(input, _repeated_outputs_codec);
+                break;
+              }
             }
           }
         #endif
@@ -7194,6 +7460,10 @@ namespace Cerbos.Api.V1.Policy {
               }
               case 26: {
                 actions_.AddEntriesFrom(ref input, _map_actions_codec);
+                break;
+              }
+              case 34: {
+                outputs_.AddEntriesFrom(ref input, _repeated_outputs_codec);
                 break;
               }
             }
@@ -7249,6 +7519,7 @@ namespace Cerbos.Api.V1.Policy {
       input_ = other.input_ != null ? other.input_.Clone() : null;
       expected_ = other.expected_.Clone();
       options_ = other.options_ != null ? other.options_.Clone() : null;
+      expectedOutputs_ = other.expectedOutputs_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -7341,6 +7612,17 @@ namespace Cerbos.Api.V1.Policy {
       }
     }
 
+    /// <summary>Field number for the "expected_outputs" field.</summary>
+    public const int ExpectedOutputsFieldNumber = 8;
+    private static readonly pbc::MapField<string, global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries>.Codec _map_expectedOutputs_codec
+        = new pbc::MapField<string, global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries.Parser), 66);
+    private readonly pbc::MapField<string, global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries> expectedOutputs_ = new pbc::MapField<string, global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::MapField<string, global::Cerbos.Api.V1.Policy.Test.Types.OutputEntries> ExpectedOutputs {
+      get { return expectedOutputs_; }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -7363,6 +7645,7 @@ namespace Cerbos.Api.V1.Policy {
       if (!object.Equals(Input, other.Input)) return false;
       if (!Expected.Equals(other.Expected)) return false;
       if (!object.Equals(Options, other.Options)) return false;
+      if (!ExpectedOutputs.Equals(other.ExpectedOutputs)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -7377,6 +7660,7 @@ namespace Cerbos.Api.V1.Policy {
       if (input_ != null) hash ^= Input.GetHashCode();
       hash ^= Expected.GetHashCode();
       if (options_ != null) hash ^= Options.GetHashCode();
+      hash ^= ExpectedOutputs.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -7420,6 +7704,7 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(58);
         output.WriteMessage(Options);
       }
+      expectedOutputs_.WriteTo(output, _map_expectedOutputs_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -7455,6 +7740,7 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(58);
         output.WriteMessage(Options);
       }
+      expectedOutputs_.WriteTo(ref output, _map_expectedOutputs_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -7484,6 +7770,7 @@ namespace Cerbos.Api.V1.Policy {
       if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
+      size += expectedOutputs_.CalculateSize(_map_expectedOutputs_codec);
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -7524,6 +7811,7 @@ namespace Cerbos.Api.V1.Policy {
         }
         Options.MergeFrom(other.Options);
       }
+      expectedOutputs_.MergeFrom(other.expectedOutputs_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -7576,6 +7864,10 @@ namespace Cerbos.Api.V1.Policy {
             input.ReadMessage(Options);
             break;
           }
+          case 66: {
+            expectedOutputs_.AddEntriesFrom(input, _map_expectedOutputs_codec);
+            break;
+          }
         }
       }
     #endif
@@ -7626,6 +7918,10 @@ namespace Cerbos.Api.V1.Policy {
               Options = new global::Cerbos.Api.V1.Policy.TestOptions();
             }
             input.ReadMessage(Options);
+            break;
+          }
+          case 66: {
+            expectedOutputs_.AddEntriesFrom(ref input, _map_expectedOutputs_codec);
             break;
           }
         }
@@ -7892,6 +8188,184 @@ namespace Cerbos.Api.V1.Policy {
               }
               case 26: {
                 ResourceKey = input.ReadString();
+                break;
+              }
+            }
+          }
+        }
+        #endif
+
+      }
+
+      public sealed partial class OutputEntries : pb::IMessage<OutputEntries>
+      #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          , pb::IBufferMessage
+      #endif
+      {
+        private static readonly pb::MessageParser<OutputEntries> _parser = new pb::MessageParser<OutputEntries>(() => new OutputEntries());
+        private pb::UnknownFieldSet _unknownFields;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static pb::MessageParser<OutputEntries> Parser { get { return _parser; } }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static pbr::MessageDescriptor Descriptor {
+          get { return global::Cerbos.Api.V1.Policy.Test.Descriptor.NestedTypes[1]; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        pbr::MessageDescriptor pb::IMessage.Descriptor {
+          get { return Descriptor; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputEntries() {
+          OnConstruction();
+        }
+
+        partial void OnConstruction();
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputEntries(OutputEntries other) : this() {
+          entries_ = other.entries_.Clone();
+          _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputEntries Clone() {
+          return new OutputEntries(this);
+        }
+
+        /// <summary>Field number for the "entries" field.</summary>
+        public const int EntriesFieldNumber = 1;
+        private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_entries_codec
+            = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 10);
+        private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> entries_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Entries {
+          get { return entries_; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override bool Equals(object other) {
+          return Equals(other as OutputEntries);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool Equals(OutputEntries other) {
+          if (ReferenceEquals(other, null)) {
+            return false;
+          }
+          if (ReferenceEquals(other, this)) {
+            return true;
+          }
+          if (!Entries.Equals(other.Entries)) return false;
+          return Equals(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override int GetHashCode() {
+          int hash = 1;
+          hash ^= Entries.GetHashCode();
+          if (_unknownFields != null) {
+            hash ^= _unknownFields.GetHashCode();
+          }
+          return hash;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override string ToString() {
+          return pb::JsonFormatter.ToDiagnosticString(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void WriteTo(pb::CodedOutputStream output) {
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          output.WriteRawMessage(this);
+        #else
+          entries_.WriteTo(output, _map_entries_codec);
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(output);
+          }
+        #endif
+        }
+
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+          entries_.WriteTo(ref output, _map_entries_codec);
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(ref output);
+          }
+        }
+        #endif
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public int CalculateSize() {
+          int size = 0;
+          size += entries_.CalculateSize(_map_entries_codec);
+          if (_unknownFields != null) {
+            size += _unknownFields.CalculateSize();
+          }
+          return size;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void MergeFrom(OutputEntries other) {
+          if (other == null) {
+            return;
+          }
+          entries_.MergeFrom(other.entries_);
+          _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void MergeFrom(pb::CodedInputStream input) {
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          input.ReadRawMessage(this);
+        #else
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                break;
+              case 10: {
+                entries_.AddEntriesFrom(input, _map_entries_codec);
+                break;
+              }
+            }
+          }
+        #endif
+        }
+
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                break;
+              case 10: {
+                entries_.AddEntriesFrom(ref input, _map_entries_codec);
                 break;
               }
             }
@@ -10247,6 +10721,778 @@ namespace Cerbos.Api.V1.Policy {
 
       }
 
+      public sealed partial class OutputFailure : pb::IMessage<OutputFailure>
+      #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          , pb::IBufferMessage
+      #endif
+      {
+        private static readonly pb::MessageParser<OutputFailure> _parser = new pb::MessageParser<OutputFailure>(() => new OutputFailure());
+        private pb::UnknownFieldSet _unknownFields;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static pb::MessageParser<OutputFailure> Parser { get { return _parser; } }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static pbr::MessageDescriptor Descriptor {
+          get { return global::Cerbos.Api.V1.Policy.TestResults.Descriptor.NestedTypes[8]; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        pbr::MessageDescriptor pb::IMessage.Descriptor {
+          get { return Descriptor; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputFailure() {
+          OnConstruction();
+        }
+
+        partial void OnConstruction();
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputFailure(OutputFailure other) : this() {
+          src_ = other.src_;
+          switch (other.OutcomeCase) {
+            case OutcomeOneofCase.Mismatched:
+              Mismatched = other.Mismatched.Clone();
+              break;
+            case OutcomeOneofCase.Missing:
+              Missing = other.Missing.Clone();
+              break;
+          }
+
+          _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutputFailure Clone() {
+          return new OutputFailure(this);
+        }
+
+        /// <summary>Field number for the "src" field.</summary>
+        public const int SrcFieldNumber = 1;
+        private string src_ = "";
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public string Src {
+          get { return src_; }
+          set {
+            src_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+          }
+        }
+
+        /// <summary>Field number for the "mismatched" field.</summary>
+        public const int MismatchedFieldNumber = 2;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue Mismatched {
+          get { return outcomeCase_ == OutcomeOneofCase.Mismatched ? (global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue) outcome_ : null; }
+          set {
+            outcome_ = value;
+            outcomeCase_ = value == null ? OutcomeOneofCase.None : OutcomeOneofCase.Mismatched;
+          }
+        }
+
+        /// <summary>Field number for the "missing" field.</summary>
+        public const int MissingFieldNumber = 3;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue Missing {
+          get { return outcomeCase_ == OutcomeOneofCase.Missing ? (global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue) outcome_ : null; }
+          set {
+            outcome_ = value;
+            outcomeCase_ = value == null ? OutcomeOneofCase.None : OutcomeOneofCase.Missing;
+          }
+        }
+
+        private object outcome_;
+        /// <summary>Enum of possible cases for the "outcome" oneof.</summary>
+        public enum OutcomeOneofCase {
+          None = 0,
+          Mismatched = 2,
+          Missing = 3,
+        }
+        private OutcomeOneofCase outcomeCase_ = OutcomeOneofCase.None;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public OutcomeOneofCase OutcomeCase {
+          get { return outcomeCase_; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearOutcome() {
+          outcomeCase_ = OutcomeOneofCase.None;
+          outcome_ = null;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override bool Equals(object other) {
+          return Equals(other as OutputFailure);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool Equals(OutputFailure other) {
+          if (ReferenceEquals(other, null)) {
+            return false;
+          }
+          if (ReferenceEquals(other, this)) {
+            return true;
+          }
+          if (Src != other.Src) return false;
+          if (!object.Equals(Mismatched, other.Mismatched)) return false;
+          if (!object.Equals(Missing, other.Missing)) return false;
+          if (OutcomeCase != other.OutcomeCase) return false;
+          return Equals(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override int GetHashCode() {
+          int hash = 1;
+          if (Src.Length != 0) hash ^= Src.GetHashCode();
+          if (outcomeCase_ == OutcomeOneofCase.Mismatched) hash ^= Mismatched.GetHashCode();
+          if (outcomeCase_ == OutcomeOneofCase.Missing) hash ^= Missing.GetHashCode();
+          hash ^= (int) outcomeCase_;
+          if (_unknownFields != null) {
+            hash ^= _unknownFields.GetHashCode();
+          }
+          return hash;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public override string ToString() {
+          return pb::JsonFormatter.ToDiagnosticString(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void WriteTo(pb::CodedOutputStream output) {
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          output.WriteRawMessage(this);
+        #else
+          if (Src.Length != 0) {
+            output.WriteRawTag(10);
+            output.WriteString(Src);
+          }
+          if (outcomeCase_ == OutcomeOneofCase.Mismatched) {
+            output.WriteRawTag(18);
+            output.WriteMessage(Mismatched);
+          }
+          if (outcomeCase_ == OutcomeOneofCase.Missing) {
+            output.WriteRawTag(26);
+            output.WriteMessage(Missing);
+          }
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(output);
+          }
+        #endif
+        }
+
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+          if (Src.Length != 0) {
+            output.WriteRawTag(10);
+            output.WriteString(Src);
+          }
+          if (outcomeCase_ == OutcomeOneofCase.Mismatched) {
+            output.WriteRawTag(18);
+            output.WriteMessage(Mismatched);
+          }
+          if (outcomeCase_ == OutcomeOneofCase.Missing) {
+            output.WriteRawTag(26);
+            output.WriteMessage(Missing);
+          }
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(ref output);
+          }
+        }
+        #endif
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public int CalculateSize() {
+          int size = 0;
+          if (Src.Length != 0) {
+            size += 1 + pb::CodedOutputStream.ComputeStringSize(Src);
+          }
+          if (outcomeCase_ == OutcomeOneofCase.Mismatched) {
+            size += 1 + pb::CodedOutputStream.ComputeMessageSize(Mismatched);
+          }
+          if (outcomeCase_ == OutcomeOneofCase.Missing) {
+            size += 1 + pb::CodedOutputStream.ComputeMessageSize(Missing);
+          }
+          if (_unknownFields != null) {
+            size += _unknownFields.CalculateSize();
+          }
+          return size;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void MergeFrom(OutputFailure other) {
+          if (other == null) {
+            return;
+          }
+          if (other.Src.Length != 0) {
+            Src = other.Src;
+          }
+          switch (other.OutcomeCase) {
+            case OutcomeOneofCase.Mismatched:
+              if (Mismatched == null) {
+                Mismatched = new global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue();
+              }
+              Mismatched.MergeFrom(other.Mismatched);
+              break;
+            case OutcomeOneofCase.Missing:
+              if (Missing == null) {
+                Missing = new global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue();
+              }
+              Missing.MergeFrom(other.Missing);
+              break;
+          }
+
+          _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void MergeFrom(pb::CodedInputStream input) {
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+          input.ReadRawMessage(this);
+        #else
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                break;
+              case 10: {
+                Src = input.ReadString();
+                break;
+              }
+              case 18: {
+                global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue subBuilder = new global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue();
+                if (outcomeCase_ == OutcomeOneofCase.Mismatched) {
+                  subBuilder.MergeFrom(Mismatched);
+                }
+                input.ReadMessage(subBuilder);
+                Mismatched = subBuilder;
+                break;
+              }
+              case 26: {
+                global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue subBuilder = new global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue();
+                if (outcomeCase_ == OutcomeOneofCase.Missing) {
+                  subBuilder.MergeFrom(Missing);
+                }
+                input.ReadMessage(subBuilder);
+                Missing = subBuilder;
+                break;
+              }
+            }
+          }
+        #endif
+        }
+
+        #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                break;
+              case 10: {
+                Src = input.ReadString();
+                break;
+              }
+              case 18: {
+                global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue subBuilder = new global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MismatchedValue();
+                if (outcomeCase_ == OutcomeOneofCase.Mismatched) {
+                  subBuilder.MergeFrom(Mismatched);
+                }
+                input.ReadMessage(subBuilder);
+                Mismatched = subBuilder;
+                break;
+              }
+              case 26: {
+                global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue subBuilder = new global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Types.MissingValue();
+                if (outcomeCase_ == OutcomeOneofCase.Missing) {
+                  subBuilder.MergeFrom(Missing);
+                }
+                input.ReadMessage(subBuilder);
+                Missing = subBuilder;
+                break;
+              }
+            }
+          }
+        }
+        #endif
+
+        #region Nested types
+        /// <summary>Container for nested types declared in the OutputFailure message type.</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public static partial class Types {
+          public sealed partial class MismatchedValue : pb::IMessage<MismatchedValue>
+          #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+              , pb::IBufferMessage
+          #endif
+          {
+            private static readonly pb::MessageParser<MismatchedValue> _parser = new pb::MessageParser<MismatchedValue>(() => new MismatchedValue());
+            private pb::UnknownFieldSet _unknownFields;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public static pb::MessageParser<MismatchedValue> Parser { get { return _parser; } }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public static pbr::MessageDescriptor Descriptor {
+              get { return global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Descriptor.NestedTypes[0]; }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            pbr::MessageDescriptor pb::IMessage.Descriptor {
+              get { return Descriptor; }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public MismatchedValue() {
+              OnConstruction();
+            }
+
+            partial void OnConstruction();
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public MismatchedValue(MismatchedValue other) : this() {
+              expected_ = other.expected_ != null ? other.expected_.Clone() : null;
+              actual_ = other.actual_ != null ? other.actual_.Clone() : null;
+              _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public MismatchedValue Clone() {
+              return new MismatchedValue(this);
+            }
+
+            /// <summary>Field number for the "expected" field.</summary>
+            public const int ExpectedFieldNumber = 1;
+            private global::Google.Protobuf.WellKnownTypes.Value expected_;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public global::Google.Protobuf.WellKnownTypes.Value Expected {
+              get { return expected_; }
+              set {
+                expected_ = value;
+              }
+            }
+
+            /// <summary>Field number for the "actual" field.</summary>
+            public const int ActualFieldNumber = 2;
+            private global::Google.Protobuf.WellKnownTypes.Value actual_;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public global::Google.Protobuf.WellKnownTypes.Value Actual {
+              get { return actual_; }
+              set {
+                actual_ = value;
+              }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public override bool Equals(object other) {
+              return Equals(other as MismatchedValue);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public bool Equals(MismatchedValue other) {
+              if (ReferenceEquals(other, null)) {
+                return false;
+              }
+              if (ReferenceEquals(other, this)) {
+                return true;
+              }
+              if (!object.Equals(Expected, other.Expected)) return false;
+              if (!object.Equals(Actual, other.Actual)) return false;
+              return Equals(_unknownFields, other._unknownFields);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public override int GetHashCode() {
+              int hash = 1;
+              if (expected_ != null) hash ^= Expected.GetHashCode();
+              if (actual_ != null) hash ^= Actual.GetHashCode();
+              if (_unknownFields != null) {
+                hash ^= _unknownFields.GetHashCode();
+              }
+              return hash;
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public override string ToString() {
+              return pb::JsonFormatter.ToDiagnosticString(this);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void WriteTo(pb::CodedOutputStream output) {
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+              output.WriteRawMessage(this);
+            #else
+              if (expected_ != null) {
+                output.WriteRawTag(10);
+                output.WriteMessage(Expected);
+              }
+              if (actual_ != null) {
+                output.WriteRawTag(18);
+                output.WriteMessage(Actual);
+              }
+              if (_unknownFields != null) {
+                _unknownFields.WriteTo(output);
+              }
+            #endif
+            }
+
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+              if (expected_ != null) {
+                output.WriteRawTag(10);
+                output.WriteMessage(Expected);
+              }
+              if (actual_ != null) {
+                output.WriteRawTag(18);
+                output.WriteMessage(Actual);
+              }
+              if (_unknownFields != null) {
+                _unknownFields.WriteTo(ref output);
+              }
+            }
+            #endif
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public int CalculateSize() {
+              int size = 0;
+              if (expected_ != null) {
+                size += 1 + pb::CodedOutputStream.ComputeMessageSize(Expected);
+              }
+              if (actual_ != null) {
+                size += 1 + pb::CodedOutputStream.ComputeMessageSize(Actual);
+              }
+              if (_unknownFields != null) {
+                size += _unknownFields.CalculateSize();
+              }
+              return size;
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void MergeFrom(MismatchedValue other) {
+              if (other == null) {
+                return;
+              }
+              if (other.expected_ != null) {
+                if (expected_ == null) {
+                  Expected = new global::Google.Protobuf.WellKnownTypes.Value();
+                }
+                Expected.MergeFrom(other.Expected);
+              }
+              if (other.actual_ != null) {
+                if (actual_ == null) {
+                  Actual = new global::Google.Protobuf.WellKnownTypes.Value();
+                }
+                Actual.MergeFrom(other.Actual);
+              }
+              _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void MergeFrom(pb::CodedInputStream input) {
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+              input.ReadRawMessage(this);
+            #else
+              uint tag;
+              while ((tag = input.ReadTag()) != 0) {
+                switch(tag) {
+                  default:
+                    _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                    break;
+                  case 10: {
+                    if (expected_ == null) {
+                      Expected = new global::Google.Protobuf.WellKnownTypes.Value();
+                    }
+                    input.ReadMessage(Expected);
+                    break;
+                  }
+                  case 18: {
+                    if (actual_ == null) {
+                      Actual = new global::Google.Protobuf.WellKnownTypes.Value();
+                    }
+                    input.ReadMessage(Actual);
+                    break;
+                  }
+                }
+              }
+            #endif
+            }
+
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+              uint tag;
+              while ((tag = input.ReadTag()) != 0) {
+                switch(tag) {
+                  default:
+                    _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                    break;
+                  case 10: {
+                    if (expected_ == null) {
+                      Expected = new global::Google.Protobuf.WellKnownTypes.Value();
+                    }
+                    input.ReadMessage(Expected);
+                    break;
+                  }
+                  case 18: {
+                    if (actual_ == null) {
+                      Actual = new global::Google.Protobuf.WellKnownTypes.Value();
+                    }
+                    input.ReadMessage(Actual);
+                    break;
+                  }
+                }
+              }
+            }
+            #endif
+
+          }
+
+          public sealed partial class MissingValue : pb::IMessage<MissingValue>
+          #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+              , pb::IBufferMessage
+          #endif
+          {
+            private static readonly pb::MessageParser<MissingValue> _parser = new pb::MessageParser<MissingValue>(() => new MissingValue());
+            private pb::UnknownFieldSet _unknownFields;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public static pb::MessageParser<MissingValue> Parser { get { return _parser; } }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public static pbr::MessageDescriptor Descriptor {
+              get { return global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Descriptor.NestedTypes[1]; }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            pbr::MessageDescriptor pb::IMessage.Descriptor {
+              get { return Descriptor; }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public MissingValue() {
+              OnConstruction();
+            }
+
+            partial void OnConstruction();
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public MissingValue(MissingValue other) : this() {
+              expected_ = other.expected_ != null ? other.expected_.Clone() : null;
+              _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public MissingValue Clone() {
+              return new MissingValue(this);
+            }
+
+            /// <summary>Field number for the "expected" field.</summary>
+            public const int ExpectedFieldNumber = 1;
+            private global::Google.Protobuf.WellKnownTypes.Value expected_;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public global::Google.Protobuf.WellKnownTypes.Value Expected {
+              get { return expected_; }
+              set {
+                expected_ = value;
+              }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public override bool Equals(object other) {
+              return Equals(other as MissingValue);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public bool Equals(MissingValue other) {
+              if (ReferenceEquals(other, null)) {
+                return false;
+              }
+              if (ReferenceEquals(other, this)) {
+                return true;
+              }
+              if (!object.Equals(Expected, other.Expected)) return false;
+              return Equals(_unknownFields, other._unknownFields);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public override int GetHashCode() {
+              int hash = 1;
+              if (expected_ != null) hash ^= Expected.GetHashCode();
+              if (_unknownFields != null) {
+                hash ^= _unknownFields.GetHashCode();
+              }
+              return hash;
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public override string ToString() {
+              return pb::JsonFormatter.ToDiagnosticString(this);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void WriteTo(pb::CodedOutputStream output) {
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+              output.WriteRawMessage(this);
+            #else
+              if (expected_ != null) {
+                output.WriteRawTag(10);
+                output.WriteMessage(Expected);
+              }
+              if (_unknownFields != null) {
+                _unknownFields.WriteTo(output);
+              }
+            #endif
+            }
+
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+              if (expected_ != null) {
+                output.WriteRawTag(10);
+                output.WriteMessage(Expected);
+              }
+              if (_unknownFields != null) {
+                _unknownFields.WriteTo(ref output);
+              }
+            }
+            #endif
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public int CalculateSize() {
+              int size = 0;
+              if (expected_ != null) {
+                size += 1 + pb::CodedOutputStream.ComputeMessageSize(Expected);
+              }
+              if (_unknownFields != null) {
+                size += _unknownFields.CalculateSize();
+              }
+              return size;
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void MergeFrom(MissingValue other) {
+              if (other == null) {
+                return;
+              }
+              if (other.expected_ != null) {
+                if (expected_ == null) {
+                  Expected = new global::Google.Protobuf.WellKnownTypes.Value();
+                }
+                Expected.MergeFrom(other.Expected);
+              }
+              _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void MergeFrom(pb::CodedInputStream input) {
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+              input.ReadRawMessage(this);
+            #else
+              uint tag;
+              while ((tag = input.ReadTag()) != 0) {
+                switch(tag) {
+                  default:
+                    _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                    break;
+                  case 10: {
+                    if (expected_ == null) {
+                      Expected = new global::Google.Protobuf.WellKnownTypes.Value();
+                    }
+                    input.ReadMessage(Expected);
+                    break;
+                  }
+                }
+              }
+            #endif
+            }
+
+            #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+              uint tag;
+              while ((tag = input.ReadTag()) != 0) {
+                switch(tag) {
+                  default:
+                    _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                    break;
+                  case 10: {
+                    if (expected_ == null) {
+                      Expected = new global::Google.Protobuf.WellKnownTypes.Value();
+                    }
+                    input.ReadMessage(Expected);
+                    break;
+                  }
+                }
+              }
+            }
+            #endif
+
+          }
+
+        }
+        #endregion
+
+      }
+
       public sealed partial class Failure : pb::IMessage<Failure>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage
@@ -10261,7 +11507,7 @@ namespace Cerbos.Api.V1.Policy {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::Cerbos.Api.V1.Policy.TestResults.Descriptor.NestedTypes[8]; }
+          get { return global::Cerbos.Api.V1.Policy.TestResults.Descriptor.NestedTypes[9]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10283,6 +11529,7 @@ namespace Cerbos.Api.V1.Policy {
         public Failure(Failure other) : this() {
           expected_ = other.expected_;
           actual_ = other.actual_;
+          outputs_ = other.outputs_.Clone();
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -10316,6 +11563,17 @@ namespace Cerbos.Api.V1.Policy {
           }
         }
 
+        /// <summary>Field number for the "outputs" field.</summary>
+        public const int OutputsFieldNumber = 3;
+        private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure> _repeated_outputs_codec
+            = pb::FieldCodec.ForMessage(26, global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure.Parser);
+        private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure> outputs_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<global::Cerbos.Api.V1.Policy.TestResults.Types.OutputFailure> Outputs {
+          get { return outputs_; }
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -10333,6 +11591,7 @@ namespace Cerbos.Api.V1.Policy {
           }
           if (Expected != other.Expected) return false;
           if (Actual != other.Actual) return false;
+          if(!outputs_.Equals(other.outputs_)) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -10342,6 +11601,7 @@ namespace Cerbos.Api.V1.Policy {
           int hash = 1;
           if (Expected != global::Cerbos.Api.V1.Effect.Effect.Unspecified) hash ^= Expected.GetHashCode();
           if (Actual != global::Cerbos.Api.V1.Effect.Effect.Unspecified) hash ^= Actual.GetHashCode();
+          hash ^= outputs_.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -10368,6 +11628,7 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteRawTag(16);
             output.WriteEnum((int) Actual);
           }
+          outputs_.WriteTo(output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -10386,6 +11647,7 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteRawTag(16);
             output.WriteEnum((int) Actual);
           }
+          outputs_.WriteTo(ref output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -10402,6 +11664,7 @@ namespace Cerbos.Api.V1.Policy {
           if (Actual != global::Cerbos.Api.V1.Effect.Effect.Unspecified) {
             size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Actual);
           }
+          size += outputs_.CalculateSize(_repeated_outputs_codec);
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
           }
@@ -10420,6 +11683,7 @@ namespace Cerbos.Api.V1.Policy {
           if (other.Actual != global::Cerbos.Api.V1.Effect.Effect.Unspecified) {
             Actual = other.Actual;
           }
+          outputs_.Add(other.outputs_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -10443,6 +11707,10 @@ namespace Cerbos.Api.V1.Policy {
                 Actual = (global::Cerbos.Api.V1.Effect.Effect) input.ReadEnum();
                 break;
               }
+              case 26: {
+                outputs_.AddEntriesFrom(input, _repeated_outputs_codec);
+                break;
+              }
             }
           }
         #endif
@@ -10464,6 +11732,10 @@ namespace Cerbos.Api.V1.Policy {
               }
               case 16: {
                 Actual = (global::Cerbos.Api.V1.Effect.Effect) input.ReadEnum();
+                break;
+              }
+              case 26: {
+                outputs_.AddEntriesFrom(ref input, _repeated_outputs_codec);
                 break;
               }
             }

--- a/src/Sdk/Cerbos/Api/V1/Policy/Policy.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Policy/Policy.g.cs
@@ -58,7 +58,7 @@ namespace Cerbos.Api.V1.Policy {
             "dWxlUgVydWxlcxJMCgVzY29wZRgFIAEoCUI2+kIzcjEyL14oW1s6YWxudW06",
             "XV1bWzp3b3JkOl1cLV0qKFwuW1s6d29yZDpdXC1dKikqKSokUgVzY29wZRIz",
             "CgdzY2hlbWFzGAYgASgLMhkuY2VyYm9zLnBvbGljeS52MS5TY2hlbWFzUgdz",
-            "Y2hlbWFzIvMCCgxSZXNvdXJjZVJ1bGUSKgoHYWN0aW9ucxgBIAMoCUIQ+kIN",
+            "Y2hlbWFzIqUDCgxSZXNvdXJjZVJ1bGUSKgoHYWN0aW9ucxgBIAMoCUIQ+kIN",
             "kgEKCAEYASIEcgIQAVIHYWN0aW9ucxJECg1kZXJpdmVkX3JvbGVzGAIgAygJ",
             "Qh/6QhySARkYASIVchMyEV5bWzp3b3JkOl1cLVwuXSskUgxkZXJpdmVkUm9s",
             "ZXMSOgoFcm9sZXMYAyADKAlCJPpCIZIBHhgBIhpyGDIWXihbWzp3b3JkOl1c",
@@ -66,158 +66,161 @@ namespace Cerbos.Api.V1.Policy {
             "LnBvbGljeS52MS5Db25kaXRpb25SCWNvbmRpdGlvbhI8CgZlZmZlY3QYBSAB",
             "KA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVjdEIK+kIHggEEGAEYAlIGZWZm",
             "ZWN0EjwKBG5hbWUYBiABKAlCKPpCJXIjMiFeKFtbOmFscGhhOl1dW1s6d29y",
-            "ZDpdXEBcLlwtXSopKiRSBG5hbWUirgIKD1ByaW5jaXBhbFBvbGljeRJmCglw",
-            "cmluY2lwYWwYASABKAlCSPpCRXJDEAEyP15bWzphbHBoYTpdXVtbOndvcmQ6",
-            "XVxAXC5cLV0qKFw6W1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwuXC1dKikqJFIJ",
-            "cHJpbmNpcGFsEi4KB3ZlcnNpb24YAiABKAlCFPpCEXIPMg1eW1s6d29yZDpd",
-            "XSskUgd2ZXJzaW9uEjUKBXJ1bGVzGAMgAygLMh8uY2VyYm9zLnBvbGljeS52",
-            "MS5QcmluY2lwYWxSdWxlUgVydWxlcxJMCgVzY29wZRgEIAEoCUI2+kIzcjEy",
-            "L14oW1s6YWxudW06XV1bWzp3b3JkOl1cLV0qKFwuW1s6d29yZDpdXC1dKikq",
-            "KSokUgVzY29wZSLjAgoNUHJpbmNpcGFsUnVsZRIjCghyZXNvdXJjZRgBIAEo",
-            "CUIH+kIEcgIQAVIIcmVzb3VyY2USSgoHYWN0aW9ucxgCIAMoCzImLmNlcmJv",
-            "cy5wb2xpY3kudjEuUHJpbmNpcGFsUnVsZS5BY3Rpb25CCPpCBZIBAggBUgdh",
-            "Y3Rpb25zGuABCgZBY3Rpb24SHwoGYWN0aW9uGAEgASgJQgf6QgRyAhABUgZh",
-            "Y3Rpb24SOQoJY29uZGl0aW9uGAIgASgLMhsuY2VyYm9zLnBvbGljeS52MS5D",
-            "b25kaXRpb25SCWNvbmRpdGlvbhI8CgZlZmZlY3QYAyABKA4yGC5jZXJib3Mu",
-            "ZWZmZWN0LnYxLkVmZmVjdEIK+kIHggEEGAEYAlIGZWZmZWN0EjwKBG5hbWUY",
-            "BCABKAlCKPpCJXIjMiFeKFtbOmFscGhhOl1dW1s6d29yZDpdXEBcLlwtXSop",
-            "KiRSBG5hbWUihQEKDERlcml2ZWRSb2xlcxIuCgRuYW1lGAEgASgJQhr6Qhdy",
-            "FRABMhFeW1s6d29yZDpdXC1cLl0rJFIEbmFtZRJFCgtkZWZpbml0aW9ucxgC",
-            "IAMoCzIZLmNlcmJvcy5wb2xpY3kudjEuUm9sZURlZkII+kIFkgECCAFSC2Rl",
-            "ZmluaXRpb25zIr0BCgdSb2xlRGVmEiwKBG5hbWUYASABKAlCGPpCFXITMhFe",
-            "W1s6d29yZDpdXC1cLl0rJFIEbmFtZRJJCgxwYXJlbnRfcm9sZXMYAiADKAlC",
-            "JvpCI5IBIAgBGAEiGnIYMhZeKFtbOndvcmQ6XVwtXC5dK3xcKikkUgtwYXJl",
-            "bnRSb2xlcxI5Cgljb25kaXRpb24YAyABKAsyGy5jZXJib3MucG9saWN5LnYx",
-            "LkNvbmRpdGlvblIJY29uZGl0aW9uImgKCUNvbmRpdGlvbhIvCgVtYXRjaBgB",
-            "IAEoCzIXLmNlcmJvcy5wb2xpY3kudjEuTWF0Y2hIAFIFbWF0Y2gSGAoGc2Ny",
-            "aXB0GAIgASgJSABSBnNjcmlwdEIQCgljb25kaXRpb24SA/hCASKLAgoFTWF0",
-            "Y2gSNAoDYWxsGAEgASgLMiAuY2VyYm9zLnBvbGljeS52MS5NYXRjaC5FeHBy",
-            "TGlzdEgAUgNhbGwSNAoDYW55GAIgASgLMiAuY2VyYm9zLnBvbGljeS52MS5N",
-            "YXRjaC5FeHByTGlzdEgAUgNhbnkSNgoEbm9uZRgDIAEoCzIgLmNlcmJvcy5w",
-            "b2xpY3kudjEuTWF0Y2guRXhwckxpc3RIAFIEbm9uZRIUCgRleHByGAQgASgJ",
-            "SABSBGV4cHIaPQoIRXhwckxpc3QSMQoCb2YYASADKAsyFy5jZXJib3MucG9s",
-            "aWN5LnYxLk1hdGNoQgj6QgWSAQIIAVICb2ZCCQoCb3ASA/hCASLHAgoHU2No",
-            "ZW1hcxJLChBwcmluY2lwYWxfc2NoZW1hGAEgASgLMiAuY2VyYm9zLnBvbGlj",
-            "eS52MS5TY2hlbWFzLlNjaGVtYVIPcHJpbmNpcGFsU2NoZW1hEkkKD3Jlc291",
-            "cmNlX3NjaGVtYRgCIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEuU2NoZW1hcy5T",
-            "Y2hlbWFSDnJlc291cmNlU2NoZW1hGjgKCklnbm9yZVdoZW4SKgoHYWN0aW9u",
-            "cxgBIAMoCUIQ+kINkgEKCAEYASIEcgIQAVIHYWN0aW9ucxpqCgZTY2hlbWES",
-            "GQoDcmVmGAEgASgJQgf6QgRyAhABUgNyZWYSRQoLaWdub3JlX3doZW4YAiAB",
-            "KAsyJC5jZXJib3MucG9saWN5LnYxLlNjaGVtYXMuSWdub3JlV2hlblIKaWdu",
-            "b3JlV2hlbiLCBAoLVGVzdEZpeHR1cmUawgEKClByaW5jaXBhbHMSWAoKcHJp",
-            "bmNpcGFscxgBIAMoCzI4LmNlcmJvcy5wb2xpY3kudjEuVGVzdEZpeHR1cmUu",
-            "UHJpbmNpcGFscy5QcmluY2lwYWxzRW50cnlSCnByaW5jaXBhbHMaWgoPUHJp",
-            "bmNpcGFsc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EjEKBXZhbHVlGAIgASgL",
-            "MhsuY2VyYm9zLmVuZ2luZS52MS5QcmluY2lwYWxSBXZhbHVlOgI4ARq7AQoJ",
-            "UmVzb3VyY2VzElQKCXJlc291cmNlcxgBIAMoCzI2LmNlcmJvcy5wb2xpY3ku",
-            "djEuVGVzdEZpeHR1cmUuUmVzb3VyY2VzLlJlc291cmNlc0VudHJ5UglyZXNv",
-            "dXJjZXMaWAoOUmVzb3VyY2VzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSMAoF",
-            "dmFsdWUYAiABKAsyGi5jZXJib3MuZW5naW5lLnYxLlJlc291cmNlUgV2YWx1",
-            "ZToCOAEarwEKB0F1eERhdGESTQoIYXV4X2RhdGEYASADKAsyMi5jZXJib3Mu",
-            "cG9saWN5LnYxLlRlc3RGaXh0dXJlLkF1eERhdGEuQXV4RGF0YUVudHJ5Ugdh",
-            "dXhEYXRhGlUKDEF1eERhdGFFbnRyeRIQCgNrZXkYASABKAlSA2tleRIvCgV2",
-            "YWx1ZRgCIAEoCzIZLmNlcmJvcy5lbmdpbmUudjEuQXV4RGF0YVIFdmFsdWU6",
-            "AjgBIjsKC1Rlc3RPcHRpb25zEiwKA25vdxgBIAEoCzIaLmdvb2dsZS5wcm90",
-            "b2J1Zi5UaW1lc3RhbXBSA25vdyLeBQoJVGVzdFN1aXRlEhsKBG5hbWUYASAB",
-            "KAlCB/pCBHICEAFSBG5hbWUSIAoLZGVzY3JpcHRpb24YAiABKAlSC2Rlc2Ny",
-            "aXB0aW9uEhIKBHNraXAYAyABKAhSBHNraXASHwoLc2tpcF9yZWFzb24YBCAB",
-            "KAlSCnNraXBSZWFzb24SOwoFdGVzdHMYBSADKAsyGy5jZXJib3MucG9saWN5",
-            "LnYxLlRlc3RUYWJsZUII+kIFkgECCAFSBXRlc3RzEksKCnByaW5jaXBhbHMY",
-            "BiADKAsyKy5jZXJib3MucG9saWN5LnYxLlRlc3RTdWl0ZS5QcmluY2lwYWxz",
-            "RW50cnlSCnByaW5jaXBhbHMSSAoJcmVzb3VyY2VzGAcgAygLMiouY2VyYm9z",
-            "LnBvbGljeS52MS5UZXN0U3VpdGUuUmVzb3VyY2VzRW50cnlSCXJlc291cmNl",
-            "cxJDCghhdXhfZGF0YRgIIAMoCzIoLmNlcmJvcy5wb2xpY3kudjEuVGVzdFN1",
-            "aXRlLkF1eERhdGFFbnRyeVIHYXV4RGF0YRI3CgdvcHRpb25zGAkgASgLMh0u",
-            "Y2VyYm9zLnBvbGljeS52MS5UZXN0T3B0aW9uc1IHb3B0aW9ucxpaCg9Qcmlu",
-            "Y2lwYWxzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSMQoFdmFsdWUYAiABKAsy",
-            "Gy5jZXJib3MuZW5naW5lLnYxLlByaW5jaXBhbFIFdmFsdWU6AjgBGlgKDlJl",
-            "c291cmNlc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EjAKBXZhbHVlGAIgASgL",
-            "MhouY2VyYm9zLmVuZ2luZS52MS5SZXNvdXJjZVIFdmFsdWU6AjgBGlUKDEF1",
-            "eERhdGFFbnRyeRIQCgNrZXkYASABKAlSA2tleRIvCgV2YWx1ZRgCIAEoCzIZ",
-            "LmNlcmJvcy5lbmdpbmUudjEuQXV4RGF0YVIFdmFsdWU6AjgBIo8GCglUZXN0",
-            "VGFibGUSGwoEbmFtZRgBIAEoCUIH+kIEcgIQAVIEbmFtZRIgCgtkZXNjcmlw",
+            "ZDpdXEBcLlwtXSopKiRSBG5hbWUSMAoGb3V0cHV0GAcgASgLMhguY2VyYm9z",
+            "LnBvbGljeS52MS5PdXRwdXRSBm91dHB1dCKuAgoPUHJpbmNpcGFsUG9saWN5",
+            "EmYKCXByaW5jaXBhbBgBIAEoCUJI+kJFckMQATI/XltbOmFscGhhOl1dW1s6",
+            "d29yZDpdXEBcLlwtXSooXDpbWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5cLV0q",
+            "KSokUglwcmluY2lwYWwSLgoHdmVyc2lvbhgCIAEoCUIU+kIRcg8yDV5bWzp3",
+            "b3JkOl1dKyRSB3ZlcnNpb24SNQoFcnVsZXMYAyADKAsyHy5jZXJib3MucG9s",
+            "aWN5LnYxLlByaW5jaXBhbFJ1bGVSBXJ1bGVzEkwKBXNjb3BlGAQgASgJQjb6",
+            "QjNyMTIvXihbWzphbG51bTpdXVtbOndvcmQ6XVwtXSooXC5bWzp3b3JkOl1c",
+            "LV0qKSopKiRSBXNjb3BlIpUDCg1QcmluY2lwYWxSdWxlEiMKCHJlc291cmNl",
+            "GAEgASgJQgf6QgRyAhABUghyZXNvdXJjZRJKCgdhY3Rpb25zGAIgAygLMiYu",
+            "Y2VyYm9zLnBvbGljeS52MS5QcmluY2lwYWxSdWxlLkFjdGlvbkII+kIFkgEC",
+            "CAFSB2FjdGlvbnMakgIKBkFjdGlvbhIfCgZhY3Rpb24YASABKAlCB/pCBHIC",
+            "EAFSBmFjdGlvbhI5Cgljb25kaXRpb24YAiABKAsyGy5jZXJib3MucG9saWN5",
+            "LnYxLkNvbmRpdGlvblIJY29uZGl0aW9uEjwKBmVmZmVjdBgDIAEoDjIYLmNl",
+            "cmJvcy5lZmZlY3QudjEuRWZmZWN0Qgr6QgeCAQQYARgCUgZlZmZlY3QSPAoE",
+            "bmFtZRgEIAEoCUIo+kIlciMyIV4oW1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwu",
+            "XC1dKikqJFIEbmFtZRIwCgZvdXRwdXQYBSABKAsyGC5jZXJib3MucG9saWN5",
+            "LnYxLk91dHB1dFIGb3V0cHV0IoUBCgxEZXJpdmVkUm9sZXMSLgoEbmFtZRgB",
+            "IAEoCUIa+kIXchUQATIRXltbOndvcmQ6XVwtXC5dKyRSBG5hbWUSRQoLZGVm",
+            "aW5pdGlvbnMYAiADKAsyGS5jZXJib3MucG9saWN5LnYxLlJvbGVEZWZCCPpC",
+            "BZIBAggBUgtkZWZpbml0aW9ucyK9AQoHUm9sZURlZhIsCgRuYW1lGAEgASgJ",
+            "Qhj6QhVyEzIRXltbOndvcmQ6XVwtXC5dKyRSBG5hbWUSSQoMcGFyZW50X3Jv",
+            "bGVzGAIgAygJQib6QiOSASAIARgBIhpyGDIWXihbWzp3b3JkOl1cLVwuXSt8",
+            "XCopJFILcGFyZW50Um9sZXMSOQoJY29uZGl0aW9uGAMgASgLMhsuY2VyYm9z",
+            "LnBvbGljeS52MS5Db25kaXRpb25SCWNvbmRpdGlvbiJoCglDb25kaXRpb24S",
+            "LwoFbWF0Y2gYASABKAsyFy5jZXJib3MucG9saWN5LnYxLk1hdGNoSABSBW1h",
+            "dGNoEhgKBnNjcmlwdBgCIAEoCUgAUgZzY3JpcHRCEAoJY29uZGl0aW9uEgP4",
+            "QgEiiwIKBU1hdGNoEjQKA2FsbBgBIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEu",
+            "TWF0Y2guRXhwckxpc3RIAFIDYWxsEjQKA2FueRgCIAEoCzIgLmNlcmJvcy5w",
+            "b2xpY3kudjEuTWF0Y2guRXhwckxpc3RIAFIDYW55EjYKBG5vbmUYAyABKAsy",
+            "IC5jZXJib3MucG9saWN5LnYxLk1hdGNoLkV4cHJMaXN0SABSBG5vbmUSFAoE",
+            "ZXhwchgEIAEoCUgAUgRleHByGj0KCEV4cHJMaXN0EjEKAm9mGAEgAygLMhcu",
+            "Y2VyYm9zLnBvbGljeS52MS5NYXRjaEII+kIFkgECCAFSAm9mQgkKAm9wEgP4",
+            "QgEiHAoGT3V0cHV0EhIKBGV4cHIYASABKAlSBGV4cHIixwIKB1NjaGVtYXMS",
+            "SwoQcHJpbmNpcGFsX3NjaGVtYRgBIAEoCzIgLmNlcmJvcy5wb2xpY3kudjEu",
+            "U2NoZW1hcy5TY2hlbWFSD3ByaW5jaXBhbFNjaGVtYRJJCg9yZXNvdXJjZV9z",
+            "Y2hlbWEYAiABKAsyIC5jZXJib3MucG9saWN5LnYxLlNjaGVtYXMuU2NoZW1h",
+            "Ug5yZXNvdXJjZVNjaGVtYRo4CgpJZ25vcmVXaGVuEioKB2FjdGlvbnMYASAD",
+            "KAlCEPpCDZIBCggBGAEiBHICEAFSB2FjdGlvbnMaagoGU2NoZW1hEhkKA3Jl",
+            "ZhgBIAEoCUIH+kIEcgIQAVIDcmVmEkUKC2lnbm9yZV93aGVuGAIgASgLMiQu",
+            "Y2VyYm9zLnBvbGljeS52MS5TY2hlbWFzLklnbm9yZVdoZW5SCmlnbm9yZVdo",
+            "ZW4iwgQKC1Rlc3RGaXh0dXJlGsIBCgpQcmluY2lwYWxzElgKCnByaW5jaXBh",
+            "bHMYASADKAsyOC5jZXJib3MucG9saWN5LnYxLlRlc3RGaXh0dXJlLlByaW5j",
+            "aXBhbHMuUHJpbmNpcGFsc0VudHJ5UgpwcmluY2lwYWxzGloKD1ByaW5jaXBh",
+            "bHNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIxCgV2YWx1ZRgCIAEoCzIbLmNl",
+            "cmJvcy5lbmdpbmUudjEuUHJpbmNpcGFsUgV2YWx1ZToCOAEauwEKCVJlc291",
+            "cmNlcxJUCglyZXNvdXJjZXMYASADKAsyNi5jZXJib3MucG9saWN5LnYxLlRl",
+            "c3RGaXh0dXJlLlJlc291cmNlcy5SZXNvdXJjZXNFbnRyeVIJcmVzb3VyY2Vz",
+            "GlgKDlJlc291cmNlc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EjAKBXZhbHVl",
+            "GAIgASgLMhouY2VyYm9zLmVuZ2luZS52MS5SZXNvdXJjZVIFdmFsdWU6AjgB",
+            "Gq8BCgdBdXhEYXRhEk0KCGF1eF9kYXRhGAEgAygLMjIuY2VyYm9zLnBvbGlj",
+            "eS52MS5UZXN0Rml4dHVyZS5BdXhEYXRhLkF1eERhdGFFbnRyeVIHYXV4RGF0",
+            "YRpVCgxBdXhEYXRhRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSLwoFdmFsdWUY",
+            "AiABKAsyGS5jZXJib3MuZW5naW5lLnYxLkF1eERhdGFSBXZhbHVlOgI4ASI7",
+            "CgtUZXN0T3B0aW9ucxIsCgNub3cYASABKAsyGi5nb29nbGUucHJvdG9idWYu",
+            "VGltZXN0YW1wUgNub3ci3gUKCVRlc3RTdWl0ZRIbCgRuYW1lGAEgASgJQgf6",
+            "QgRyAhABUgRuYW1lEiAKC2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlv",
+            "bhISCgRza2lwGAMgASgIUgRza2lwEh8KC3NraXBfcmVhc29uGAQgASgJUgpz",
+            "a2lwUmVhc29uEjsKBXRlc3RzGAUgAygLMhsuY2VyYm9zLnBvbGljeS52MS5U",
+            "ZXN0VGFibGVCCPpCBZIBAggBUgV0ZXN0cxJLCgpwcmluY2lwYWxzGAYgAygL",
+            "MisuY2VyYm9zLnBvbGljeS52MS5UZXN0U3VpdGUuUHJpbmNpcGFsc0VudHJ5",
+            "UgpwcmluY2lwYWxzEkgKCXJlc291cmNlcxgHIAMoCzIqLmNlcmJvcy5wb2xp",
+            "Y3kudjEuVGVzdFN1aXRlLlJlc291cmNlc0VudHJ5UglyZXNvdXJjZXMSQwoI",
+            "YXV4X2RhdGEYCCADKAsyKC5jZXJib3MucG9saWN5LnYxLlRlc3RTdWl0ZS5B",
+            "dXhEYXRhRW50cnlSB2F1eERhdGESNwoHb3B0aW9ucxgJIAEoCzIdLmNlcmJv",
+            "cy5wb2xpY3kudjEuVGVzdE9wdGlvbnNSB29wdGlvbnMaWgoPUHJpbmNpcGFs",
+            "c0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EjEKBXZhbHVlGAIgASgLMhsuY2Vy",
+            "Ym9zLmVuZ2luZS52MS5QcmluY2lwYWxSBXZhbHVlOgI4ARpYCg5SZXNvdXJj",
+            "ZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIwCgV2YWx1ZRgCIAEoCzIaLmNl",
+            "cmJvcy5lbmdpbmUudjEuUmVzb3VyY2VSBXZhbHVlOgI4ARpVCgxBdXhEYXRh",
+            "RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSLwoFdmFsdWUYAiABKAsyGS5jZXJi",
+            "b3MuZW5naW5lLnYxLkF1eERhdGFSBXZhbHVlOgI4ASKPBgoJVGVzdFRhYmxl",
+            "EhsKBG5hbWUYASABKAlCB/pCBHICEAFSBG5hbWUSIAoLZGVzY3JpcHRpb24Y",
+            "AiABKAlSC2Rlc2NyaXB0aW9uEhIKBHNraXAYAyABKAhSBHNraXASHwoLc2tp",
+            "cF9yZWFzb24YBCABKAlSCnNraXBSZWFzb24SQQoFaW5wdXQYBSABKAsyIS5j",
+            "ZXJib3MucG9saWN5LnYxLlRlc3RUYWJsZS5JbnB1dEII+kIFigECEAFSBWlu",
+            "cHV0Ek0KCGV4cGVjdGVkGAYgAygLMicuY2VyYm9zLnBvbGljeS52MS5UZXN0",
+            "VGFibGUuRXhwZWN0YXRpb25CCPpCBZIBAggBUghleHBlY3RlZBI3CgdvcHRp",
+            "b25zGAcgASgLMh0uY2VyYm9zLnBvbGljeS52MS5UZXN0T3B0aW9uc1IHb3B0",
+            "aW9ucxqwAQoFSW5wdXQSMAoKcHJpbmNpcGFscxgBIAMoCUIQ+kINkgEKCAEY",
+            "ASIEcgIQAVIKcHJpbmNpcGFscxIuCglyZXNvdXJjZXMYAiADKAlCEPpCDZIB",
+            "CggBGAEiBHICEAFSCXJlc291cmNlcxIqCgdhY3Rpb25zGAMgAygJQhD6Qg2S",
+            "AQoIARgBIgRyAhABUgdhY3Rpb25zEhkKCGF1eF9kYXRhGAQgASgJUgdhdXhE",
+            "YXRhGo8CCgtFeHBlY3RhdGlvbhIlCglwcmluY2lwYWwYASABKAlCB/pCBHIC",
+            "EAFSCXByaW5jaXBhbBIjCghyZXNvdXJjZRgCIAEoCUIH+kIEcgIQAVIIcmVz",
+            "b3VyY2USXgoHYWN0aW9ucxgDIAMoCzI0LmNlcmJvcy5wb2xpY3kudjEuVGVz",
+            "dFRhYmxlLkV4cGVjdGF0aW9uLkFjdGlvbnNFbnRyeUIO+kILmgEICAEiBHIC",
+            "EAFSB2FjdGlvbnMaVAoMQWN0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5",
+            "Ei4KBXZhbHVlGAIgASgOMhguY2VyYm9zLmVmZmVjdC52MS5FZmZlY3RSBXZh",
+            "bHVlOgI4ASLUBAoEVGVzdBI9CgRuYW1lGAEgASgLMh8uY2VyYm9zLnBvbGlj",
+            "eS52MS5UZXN0LlRlc3ROYW1lQgj6QgWKAQIQAVIEbmFtZRIgCgtkZXNjcmlw",
             "dGlvbhgCIAEoCVILZGVzY3JpcHRpb24SEgoEc2tpcBgDIAEoCFIEc2tpcBIf",
-            "Cgtza2lwX3JlYXNvbhgEIAEoCVIKc2tpcFJlYXNvbhJBCgVpbnB1dBgFIAEo",
-            "CzIhLmNlcmJvcy5wb2xpY3kudjEuVGVzdFRhYmxlLklucHV0Qgj6QgWKAQIQ",
-            "AVIFaW5wdXQSTQoIZXhwZWN0ZWQYBiADKAsyJy5jZXJib3MucG9saWN5LnYx",
-            "LlRlc3RUYWJsZS5FeHBlY3RhdGlvbkII+kIFkgECCAFSCGV4cGVjdGVkEjcK",
-            "B29wdGlvbnMYByABKAsyHS5jZXJib3MucG9saWN5LnYxLlRlc3RPcHRpb25z",
-            "UgdvcHRpb25zGrABCgVJbnB1dBIwCgpwcmluY2lwYWxzGAEgAygJQhD6Qg2S",
-            "AQoIARgBIgRyAhABUgpwcmluY2lwYWxzEi4KCXJlc291cmNlcxgCIAMoCUIQ",
-            "+kINkgEKCAEYASIEcgIQAVIJcmVzb3VyY2VzEioKB2FjdGlvbnMYAyADKAlC",
-            "EPpCDZIBCggBGAEiBHICEAFSB2FjdGlvbnMSGQoIYXV4X2RhdGEYBCABKAlS",
-            "B2F1eERhdGEajwIKC0V4cGVjdGF0aW9uEiUKCXByaW5jaXBhbBgBIAEoCUIH",
-            "+kIEcgIQAVIJcHJpbmNpcGFsEiMKCHJlc291cmNlGAIgASgJQgf6QgRyAhAB",
-            "UghyZXNvdXJjZRJeCgdhY3Rpb25zGAMgAygLMjQuY2VyYm9zLnBvbGljeS52",
-            "MS5UZXN0VGFibGUuRXhwZWN0YXRpb24uQWN0aW9uc0VudHJ5Qg76QguaAQgI",
-            "ASIEcgIQAVIHYWN0aW9ucxpUCgxBY3Rpb25zRW50cnkSEAoDa2V5GAEgASgJ",
-            "UgNrZXkSLgoFdmFsdWUYAiABKA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVj",
-            "dFIFdmFsdWU6AjgBItQECgRUZXN0Ej0KBG5hbWUYASABKAsyHy5jZXJib3Mu",
-            "cG9saWN5LnYxLlRlc3QuVGVzdE5hbWVCCPpCBYoBAhABUgRuYW1lEiAKC2Rl",
-            "c2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlvbhISCgRza2lwGAMgASgIUgRz",
-            "a2lwEh8KC3NraXBfcmVhc29uGAQgASgJUgpza2lwUmVhc29uEjwKBWlucHV0",
-            "GAUgASgLMhwuY2VyYm9zLmVuZ2luZS52MS5DaGVja0lucHV0Qgj6QgWKAQIQ",
-            "AVIFaW5wdXQSUAoIZXhwZWN0ZWQYBiADKAsyJC5jZXJib3MucG9saWN5LnYx",
-            "LlRlc3QuRXhwZWN0ZWRFbnRyeUIO+kILmgEICAEiBHICEAFSCGV4cGVjdGVk",
-            "EjcKB29wdGlvbnMYByABKAsyHS5jZXJib3MucG9saWN5LnYxLlRlc3RPcHRp",
-            "b25zUgdvcHRpb25zGpUBCghUZXN0TmFtZRIvCg90ZXN0X3RhYmxlX25hbWUY",
-            "ASABKAlCB/pCBHICEAFSDXRlc3RUYWJsZU5hbWUSLAoNcHJpbmNpcGFsX2tl",
-            "eRgCIAEoCUIH+kIEcgIQAVIMcHJpbmNpcGFsS2V5EioKDHJlc291cmNlX2tl",
-            "eRgDIAEoCUIH+kIEcgIQAVILcmVzb3VyY2VLZXkaVQoNRXhwZWN0ZWRFbnRy",
-            "eRIQCgNrZXkYASABKAlSA2tleRIuCgV2YWx1ZRgCIAEoDjIYLmNlcmJvcy5l",
-            "ZmZlY3QudjEuRWZmZWN0UgV2YWx1ZToCOAEiyQwKC1Rlc3RSZXN1bHRzEjsK",
-            "BnN1aXRlcxgBIAMoCzIjLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMu",
-            "U3VpdGVSBnN1aXRlcxI/CgdzdW1tYXJ5GAIgASgLMiUuY2VyYm9zLnBvbGlj",
-            "eS52MS5UZXN0UmVzdWx0cy5TdW1tYXJ5UgdzdW1tYXJ5GlsKBVRhbGx5EjwK",
-            "BnJlc3VsdBgBIAEoDjIkLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMu",
-            "UmVzdWx0UgZyZXN1bHQSFAoFY291bnQYAiABKA1SBWNvdW50GsEBCgdTdW1t",
-            "YXJ5EksKDm92ZXJhbGxfcmVzdWx0GAEgASgOMiQuY2VyYm9zLnBvbGljeS52",
-            "MS5UZXN0UmVzdWx0cy5SZXN1bHRSDW92ZXJhbGxSZXN1bHQSHwoLdGVzdHNf",
-            "Y291bnQYAiABKA1SCnRlc3RzQ291bnQSSAoNcmVzdWx0X2NvdW50cxgDIAMo",
-            "CzIjLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMuVGFsbHlSDHJlc3Vs",
-            "dENvdW50cxq8AgoFU3VpdGUSEgoEZmlsZRgBIAEoCVIEZmlsZRISCgRuYW1l",
-            "GAIgASgJUgRuYW1lEksKCnByaW5jaXBhbHMYAyADKAsyJy5jZXJib3MucG9s",
-            "aWN5LnYxLlRlc3RSZXN1bHRzLlByaW5jaXBhbEICGAFSCnByaW5jaXBhbHMS",
-            "PwoHc3VtbWFyeRgEIAEoCzIlLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3Vs",
-            "dHMuU3VtbWFyeVIHc3VtbWFyeRIUCgVlcnJvchgFIAEoCVIFZXJyb3ISRQoK",
-            "dGVzdF9jYXNlcxgGIAMoCzImLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3Vs",
-            "dHMuVGVzdENhc2VSCXRlc3RDYXNlcxIgCgtkZXNjcmlwdGlvbhgHIAEoCVIL",
-            "ZGVzY3JpcHRpb24aZwoIVGVzdENhc2USEgoEbmFtZRgBIAEoCVIEbmFtZRJH",
-            "CgpwcmluY2lwYWxzGAIgAygLMicuY2VyYm9zLnBvbGljeS52MS5UZXN0UmVz",
-            "dWx0cy5QcmluY2lwYWxSCnByaW5jaXBhbHMaZQoJUHJpbmNpcGFsEhIKBG5h",
-            "bWUYASABKAlSBG5hbWUSRAoJcmVzb3VyY2VzGAIgAygLMiYuY2VyYm9zLnBv",
-            "bGljeS52MS5UZXN0UmVzdWx0cy5SZXNvdXJjZVIJcmVzb3VyY2VzGl4KCFJl",
-            "c291cmNlEhIKBG5hbWUYASABKAlSBG5hbWUSPgoHYWN0aW9ucxgCIAMoCzIk",
-            "LmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMuQWN0aW9uUgdhY3Rpb25z",
-            "Gl0KBkFjdGlvbhISCgRuYW1lGAEgASgJUgRuYW1lEj8KB2RldGFpbHMYAiAB",
-            "KAsyJS5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLkRldGFpbHNSB2Rl",
-            "dGFpbHMa6QEKB0RldGFpbHMSPAoGcmVzdWx0GAEgASgOMiQuY2VyYm9zLnBv",
-            "bGljeS52MS5UZXN0UmVzdWx0cy5SZXN1bHRSBnJlc3VsdBJBCgdmYWlsdXJl",
-            "GAIgASgLMiUuY2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0cy5GYWlsdXJl",
-            "SABSB2ZhaWx1cmUSFgoFZXJyb3IYAyABKAlIAFIFZXJyb3ISOgoMZW5naW5l",
-            "X3RyYWNlGAQgAygLMhcuY2VyYm9zLmVuZ2luZS52MS5UcmFjZVILZW5naW5l",
-            "VHJhY2VCCQoHb3V0Y29tZRpxCgdGYWlsdXJlEjQKCGV4cGVjdGVkGAEgASgO",
-            "MhguY2VyYm9zLmVmZmVjdC52MS5FZmZlY3RSCGV4cGVjdGVkEjAKBmFjdHVh",
-            "bBgCIAEoDjIYLmNlcmJvcy5lZmZlY3QudjEuRWZmZWN0UgZhY3R1YWwibgoG",
-            "UmVzdWx0EhYKElJFU1VMVF9VTlNQRUNJRklFRBAAEhIKDlJFU1VMVF9TS0lQ",
-            "UEVEEAESEQoNUkVTVUxUX1BBU1NFRBACEhEKDVJFU1VMVF9GQUlMRUQQAxIS",
-            "Cg5SRVNVTFRfRVJST1JFRBAEQm8KGGRldi5jZXJib3MuYXBpLnYxLnBvbGlj",
-            "eVo8Z2l0aHViLmNvbS9jZXJib3MvY2VyYm9zL2FwaS9nZW5wYi9jZXJib3Mv",
-            "cG9saWN5L3YxO3BvbGljeXYxqgIUQ2VyYm9zLkFwaS5WMS5Qb2xpY3liBnBy",
-            "b3RvMw=="));
+            "Cgtza2lwX3JlYXNvbhgEIAEoCVIKc2tpcFJlYXNvbhI8CgVpbnB1dBgFIAEo",
+            "CzIcLmNlcmJvcy5lbmdpbmUudjEuQ2hlY2tJbnB1dEII+kIFigECEAFSBWlu",
+            "cHV0ElAKCGV4cGVjdGVkGAYgAygLMiQuY2VyYm9zLnBvbGljeS52MS5UZXN0",
+            "LkV4cGVjdGVkRW50cnlCDvpCC5oBCAgBIgRyAhABUghleHBlY3RlZBI3Cgdv",
+            "cHRpb25zGAcgASgLMh0uY2VyYm9zLnBvbGljeS52MS5UZXN0T3B0aW9uc1IH",
+            "b3B0aW9ucxqVAQoIVGVzdE5hbWUSLwoPdGVzdF90YWJsZV9uYW1lGAEgASgJ",
+            "Qgf6QgRyAhABUg10ZXN0VGFibGVOYW1lEiwKDXByaW5jaXBhbF9rZXkYAiAB",
+            "KAlCB/pCBHICEAFSDHByaW5jaXBhbEtleRIqCgxyZXNvdXJjZV9rZXkYAyAB",
+            "KAlCB/pCBHICEAFSC3Jlc291cmNlS2V5GlUKDUV4cGVjdGVkRW50cnkSEAoD",
+            "a2V5GAEgASgJUgNrZXkSLgoFdmFsdWUYAiABKA4yGC5jZXJib3MuZWZmZWN0",
+            "LnYxLkVmZmVjdFIFdmFsdWU6AjgBIskMCgtUZXN0UmVzdWx0cxI7CgZzdWl0",
+            "ZXMYASADKAsyIy5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlN1aXRl",
+            "UgZzdWl0ZXMSPwoHc3VtbWFyeRgCIAEoCzIlLmNlcmJvcy5wb2xpY3kudjEu",
+            "VGVzdFJlc3VsdHMuU3VtbWFyeVIHc3VtbWFyeRpbCgVUYWxseRI8CgZyZXN1",
+            "bHQYASABKA4yJC5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlJlc3Vs",
+            "dFIGcmVzdWx0EhQKBWNvdW50GAIgASgNUgVjb3VudBrBAQoHU3VtbWFyeRJL",
+            "Cg5vdmVyYWxsX3Jlc3VsdBgBIAEoDjIkLmNlcmJvcy5wb2xpY3kudjEuVGVz",
+            "dFJlc3VsdHMuUmVzdWx0Ug1vdmVyYWxsUmVzdWx0Eh8KC3Rlc3RzX2NvdW50",
+            "GAIgASgNUgp0ZXN0c0NvdW50EkgKDXJlc3VsdF9jb3VudHMYAyADKAsyIy5j",
+            "ZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlRhbGx5UgxyZXN1bHRDb3Vu",
+            "dHMavAIKBVN1aXRlEhIKBGZpbGUYASABKAlSBGZpbGUSEgoEbmFtZRgCIAEo",
+            "CVIEbmFtZRJLCgpwcmluY2lwYWxzGAMgAygLMicuY2VyYm9zLnBvbGljeS52",
+            "MS5UZXN0UmVzdWx0cy5QcmluY2lwYWxCAhgBUgpwcmluY2lwYWxzEj8KB3N1",
+            "bW1hcnkYBCABKAsyJS5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlN1",
+            "bW1hcnlSB3N1bW1hcnkSFAoFZXJyb3IYBSABKAlSBWVycm9yEkUKCnRlc3Rf",
+            "Y2FzZXMYBiADKAsyJi5jZXJib3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLlRl",
+            "c3RDYXNlUgl0ZXN0Q2FzZXMSIAoLZGVzY3JpcHRpb24YByABKAlSC2Rlc2Ny",
+            "aXB0aW9uGmcKCFRlc3RDYXNlEhIKBG5hbWUYASABKAlSBG5hbWUSRwoKcHJp",
+            "bmNpcGFscxgCIAMoCzInLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMu",
+            "UHJpbmNpcGFsUgpwcmluY2lwYWxzGmUKCVByaW5jaXBhbBISCgRuYW1lGAEg",
+            "ASgJUgRuYW1lEkQKCXJlc291cmNlcxgCIAMoCzImLmNlcmJvcy5wb2xpY3ku",
+            "djEuVGVzdFJlc3VsdHMuUmVzb3VyY2VSCXJlc291cmNlcxpeCghSZXNvdXJj",
+            "ZRISCgRuYW1lGAEgASgJUgRuYW1lEj4KB2FjdGlvbnMYAiADKAsyJC5jZXJi",
+            "b3MucG9saWN5LnYxLlRlc3RSZXN1bHRzLkFjdGlvblIHYWN0aW9ucxpdCgZB",
+            "Y3Rpb24SEgoEbmFtZRgBIAEoCVIEbmFtZRI/CgdkZXRhaWxzGAIgASgLMiUu",
+            "Y2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0cy5EZXRhaWxzUgdkZXRhaWxz",
+            "GukBCgdEZXRhaWxzEjwKBnJlc3VsdBgBIAEoDjIkLmNlcmJvcy5wb2xpY3ku",
+            "djEuVGVzdFJlc3VsdHMuUmVzdWx0UgZyZXN1bHQSQQoHZmFpbHVyZRgCIAEo",
+            "CzIlLmNlcmJvcy5wb2xpY3kudjEuVGVzdFJlc3VsdHMuRmFpbHVyZUgAUgdm",
+            "YWlsdXJlEhYKBWVycm9yGAMgASgJSABSBWVycm9yEjoKDGVuZ2luZV90cmFj",
+            "ZRgEIAMoCzIXLmNlcmJvcy5lbmdpbmUudjEuVHJhY2VSC2VuZ2luZVRyYWNl",
+            "QgkKB291dGNvbWUacQoHRmFpbHVyZRI0CghleHBlY3RlZBgBIAEoDjIYLmNl",
+            "cmJvcy5lZmZlY3QudjEuRWZmZWN0UghleHBlY3RlZBIwCgZhY3R1YWwYAiAB",
+            "KA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVjdFIGYWN0dWFsIm4KBlJlc3Vs",
+            "dBIWChJSRVNVTFRfVU5TUEVDSUZJRUQQABISCg5SRVNVTFRfU0tJUFBFRBAB",
+            "EhEKDVJFU1VMVF9QQVNTRUQQAhIRCg1SRVNVTFRfRkFJTEVEEAMSEgoOUkVT",
+            "VUxUX0VSUk9SRUQQBEJvChhkZXYuY2VyYm9zLmFwaS52MS5wb2xpY3laPGdp",
+            "dGh1Yi5jb20vY2VyYm9zL2NlcmJvcy9hcGkvZ2VucGIvY2VyYm9zL3BvbGlj",
+            "eS92MTtwb2xpY3l2MaoCFENlcmJvcy5BcGkuVjEuUG9saWN5YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Effect.EffectReflection.Descriptor, global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.WrappersReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Policy), global::Cerbos.Api.V1.Policy.Policy.Parser, new[]{ "ApiVersion", "Disabled", "Description", "Metadata", "ResourcePolicy", "PrincipalPolicy", "DerivedRoles", "Variables" }, new[]{ "PolicyType" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Metadata), global::Cerbos.Api.V1.Policy.Metadata.Parser, new[]{ "SourceFile", "Annotations", "Hash", "StoreIdentifer", "StoreIdentifier" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.ResourcePolicy), global::Cerbos.Api.V1.Policy.ResourcePolicy.Parser, new[]{ "Resource", "Version", "ImportDerivedRoles", "Rules", "Scope", "Schemas" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.ResourceRule), global::Cerbos.Api.V1.Policy.ResourceRule.Parser, new[]{ "Actions", "DerivedRoles", "Roles", "Condition", "Effect", "Name" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.ResourceRule), global::Cerbos.Api.V1.Policy.ResourceRule.Parser, new[]{ "Actions", "DerivedRoles", "Roles", "Condition", "Effect", "Name", "Output" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.PrincipalPolicy), global::Cerbos.Api.V1.Policy.PrincipalPolicy.Parser, new[]{ "Principal", "Version", "Rules", "Scope" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.PrincipalRule), global::Cerbos.Api.V1.Policy.PrincipalRule.Parser, new[]{ "Resource", "Actions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.PrincipalRule.Types.Action), global::Cerbos.Api.V1.Policy.PrincipalRule.Types.Action.Parser, new[]{ "Action_", "Condition", "Effect", "Name" }, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.PrincipalRule), global::Cerbos.Api.V1.Policy.PrincipalRule.Parser, new[]{ "Resource", "Actions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.PrincipalRule.Types.Action), global::Cerbos.Api.V1.Policy.PrincipalRule.Types.Action.Parser, new[]{ "Action_", "Condition", "Effect", "Name", "Output" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.DerivedRoles), global::Cerbos.Api.V1.Policy.DerivedRoles.Parser, new[]{ "Name", "Definitions" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.RoleDef), global::Cerbos.Api.V1.Policy.RoleDef.Parser, new[]{ "Name", "ParentRoles", "Condition" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Condition), global::Cerbos.Api.V1.Policy.Condition.Parser, new[]{ "Match", "Script" }, new[]{ "Condition" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Match), global::Cerbos.Api.V1.Policy.Match.Parser, new[]{ "All", "Any", "None", "Expr" }, new[]{ "Op" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Match.Types.ExprList), global::Cerbos.Api.V1.Policy.Match.Types.ExprList.Parser, new[]{ "Of" }, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Output), global::Cerbos.Api.V1.Policy.Output.Parser, new[]{ "Expr" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Schemas), global::Cerbos.Api.V1.Policy.Schemas.Parser, new[]{ "PrincipalSchema", "ResourceSchema" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Schemas.Types.IgnoreWhen), global::Cerbos.Api.V1.Policy.Schemas.Types.IgnoreWhen.Parser, new[]{ "Actions" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.Schemas.Types.Schema), global::Cerbos.Api.V1.Policy.Schemas.Types.Schema.Parser, new[]{ "Ref", "IgnoreWhen" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestFixture), global::Cerbos.Api.V1.Policy.TestFixture.Parser, null, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Policy.TestFixture.Types.Principals), global::Cerbos.Api.V1.Policy.TestFixture.Types.Principals.Parser, new[]{ "Principals_" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
@@ -606,7 +609,7 @@ namespace Cerbos.Api.V1.Policy {
         }
         Metadata.MergeFrom(other.Metadata);
       }
-      variables_.Add(other.variables_);
+      variables_.MergeFrom(other.variables_);
       switch (other.PolicyTypeCase) {
         case PolicyTypeOneofCase.ResourcePolicy:
           if (ResourcePolicy == null) {
@@ -1005,7 +1008,7 @@ namespace Cerbos.Api.V1.Policy {
       if (other.SourceFile.Length != 0) {
         SourceFile = other.SourceFile;
       }
-      annotations_.Add(other.annotations_);
+      annotations_.MergeFrom(other.annotations_);
       if (other.hash_ != null) {
         if (hash_ == null || other.Hash != 0UL) {
           Hash = other.Hash;
@@ -1501,6 +1504,7 @@ namespace Cerbos.Api.V1.Policy {
       condition_ = other.condition_ != null ? other.condition_.Clone() : null;
       effect_ = other.effect_;
       name_ = other.name_;
+      output_ = other.output_ != null ? other.output_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -1579,6 +1583,18 @@ namespace Cerbos.Api.V1.Policy {
       }
     }
 
+    /// <summary>Field number for the "output" field.</summary>
+    public const int OutputFieldNumber = 7;
+    private global::Cerbos.Api.V1.Policy.Output output_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Cerbos.Api.V1.Policy.Output Output {
+      get { return output_; }
+      set {
+        output_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -1600,6 +1616,7 @@ namespace Cerbos.Api.V1.Policy {
       if (!object.Equals(Condition, other.Condition)) return false;
       if (Effect != other.Effect) return false;
       if (Name != other.Name) return false;
+      if (!object.Equals(Output, other.Output)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1613,6 +1630,7 @@ namespace Cerbos.Api.V1.Policy {
       if (condition_ != null) hash ^= Condition.GetHashCode();
       if (Effect != global::Cerbos.Api.V1.Effect.Effect.Unspecified) hash ^= Effect.GetHashCode();
       if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (output_ != null) hash ^= Output.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1646,6 +1664,10 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(50);
         output.WriteString(Name);
       }
+      if (output_ != null) {
+        output.WriteRawTag(58);
+        output.WriteMessage(Output);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1671,6 +1693,10 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(50);
         output.WriteString(Name);
       }
+      if (output_ != null) {
+        output.WriteRawTag(58);
+        output.WriteMessage(Output);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1692,6 +1718,9 @@ namespace Cerbos.Api.V1.Policy {
       }
       if (Name.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (output_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Output);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -1719,6 +1748,12 @@ namespace Cerbos.Api.V1.Policy {
       }
       if (other.Name.Length != 0) {
         Name = other.Name;
+      }
+      if (other.output_ != null) {
+        if (output_ == null) {
+          Output = new global::Cerbos.Api.V1.Policy.Output();
+        }
+        Output.MergeFrom(other.Output);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -1762,6 +1797,13 @@ namespace Cerbos.Api.V1.Policy {
             Name = input.ReadString();
             break;
           }
+          case 58: {
+            if (output_ == null) {
+              Output = new global::Cerbos.Api.V1.Policy.Output();
+            }
+            input.ReadMessage(Output);
+            break;
+          }
         }
       }
     #endif
@@ -1802,6 +1844,13 @@ namespace Cerbos.Api.V1.Policy {
           }
           case 50: {
             Name = input.ReadString();
+            break;
+          }
+          case 58: {
+            if (output_ == null) {
+              Output = new global::Cerbos.Api.V1.Policy.Output();
+            }
+            input.ReadMessage(Output);
             break;
           }
         }
@@ -2356,6 +2405,7 @@ namespace Cerbos.Api.V1.Policy {
           condition_ = other.condition_ != null ? other.condition_.Clone() : null;
           effect_ = other.effect_;
           name_ = other.name_;
+          output_ = other.output_ != null ? other.output_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -2413,6 +2463,18 @@ namespace Cerbos.Api.V1.Policy {
           }
         }
 
+        /// <summary>Field number for the "output" field.</summary>
+        public const int OutputFieldNumber = 5;
+        private global::Cerbos.Api.V1.Policy.Output output_;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public global::Cerbos.Api.V1.Policy.Output Output {
+          get { return output_; }
+          set {
+            output_ = value;
+          }
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -2432,6 +2494,7 @@ namespace Cerbos.Api.V1.Policy {
           if (!object.Equals(Condition, other.Condition)) return false;
           if (Effect != other.Effect) return false;
           if (Name != other.Name) return false;
+          if (!object.Equals(Output, other.Output)) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -2443,6 +2506,7 @@ namespace Cerbos.Api.V1.Policy {
           if (condition_ != null) hash ^= Condition.GetHashCode();
           if (Effect != global::Cerbos.Api.V1.Effect.Effect.Unspecified) hash ^= Effect.GetHashCode();
           if (Name.Length != 0) hash ^= Name.GetHashCode();
+          if (output_ != null) hash ^= Output.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -2477,6 +2541,10 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteRawTag(34);
             output.WriteString(Name);
           }
+          if (output_ != null) {
+            output.WriteRawTag(42);
+            output.WriteMessage(Output);
+          }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -2503,6 +2571,10 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteRawTag(34);
             output.WriteString(Name);
           }
+          if (output_ != null) {
+            output.WriteRawTag(42);
+            output.WriteMessage(Output);
+          }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -2524,6 +2596,9 @@ namespace Cerbos.Api.V1.Policy {
           }
           if (Name.Length != 0) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+          }
+          if (output_ != null) {
+            size += 1 + pb::CodedOutputStream.ComputeMessageSize(Output);
           }
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
@@ -2551,6 +2626,12 @@ namespace Cerbos.Api.V1.Policy {
           }
           if (other.Name.Length != 0) {
             Name = other.Name;
+          }
+          if (other.output_ != null) {
+            if (output_ == null) {
+              Output = new global::Cerbos.Api.V1.Policy.Output();
+            }
+            Output.MergeFrom(other.Output);
           }
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
@@ -2586,6 +2667,13 @@ namespace Cerbos.Api.V1.Policy {
                 Name = input.ReadString();
                 break;
               }
+              case 42: {
+                if (output_ == null) {
+                  Output = new global::Cerbos.Api.V1.Policy.Output();
+                }
+                input.ReadMessage(Output);
+                break;
+              }
             }
           }
         #endif
@@ -2618,6 +2706,13 @@ namespace Cerbos.Api.V1.Policy {
               }
               case 34: {
                 Name = input.ReadString();
+                break;
+              }
+              case 42: {
+                if (output_ == null) {
+                  Output = new global::Cerbos.Api.V1.Policy.Output();
+                }
+                input.ReadMessage(Output);
                 break;
               }
             }
@@ -3177,10 +3272,24 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Script {
-      get { return conditionCase_ == ConditionOneofCase.Script ? (string) condition_ : ""; }
+      get { return HasScript ? (string) condition_ : ""; }
       set {
         condition_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         conditionCase_ = ConditionOneofCase.Script;
+      }
+    }
+    /// <summary>Gets whether the "script" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasScript {
+      get { return conditionCase_ == ConditionOneofCase.Script; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "script" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearScript() {
+      if (HasScript) {
+        ClearCondition();
       }
     }
 
@@ -3231,7 +3340,7 @@ namespace Cerbos.Api.V1.Policy {
     public override int GetHashCode() {
       int hash = 1;
       if (conditionCase_ == ConditionOneofCase.Match) hash ^= Match.GetHashCode();
-      if (conditionCase_ == ConditionOneofCase.Script) hash ^= Script.GetHashCode();
+      if (HasScript) hash ^= Script.GetHashCode();
       hash ^= (int) conditionCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -3255,7 +3364,7 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(10);
         output.WriteMessage(Match);
       }
-      if (conditionCase_ == ConditionOneofCase.Script) {
+      if (HasScript) {
         output.WriteRawTag(18);
         output.WriteString(Script);
       }
@@ -3273,7 +3382,7 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(10);
         output.WriteMessage(Match);
       }
-      if (conditionCase_ == ConditionOneofCase.Script) {
+      if (HasScript) {
         output.WriteRawTag(18);
         output.WriteString(Script);
       }
@@ -3290,7 +3399,7 @@ namespace Cerbos.Api.V1.Policy {
       if (conditionCase_ == ConditionOneofCase.Match) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Match);
       }
-      if (conditionCase_ == ConditionOneofCase.Script) {
+      if (HasScript) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Script);
       }
       if (_unknownFields != null) {
@@ -3479,10 +3588,24 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Expr {
-      get { return opCase_ == OpOneofCase.Expr ? (string) op_ : ""; }
+      get { return HasExpr ? (string) op_ : ""; }
       set {
         op_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         opCase_ = OpOneofCase.Expr;
+      }
+    }
+    /// <summary>Gets whether the "expr" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasExpr {
+      get { return opCase_ == OpOneofCase.Expr; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "expr" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearExpr() {
+      if (HasExpr) {
+        ClearOp();
       }
     }
 
@@ -3539,7 +3662,7 @@ namespace Cerbos.Api.V1.Policy {
       if (opCase_ == OpOneofCase.All) hash ^= All.GetHashCode();
       if (opCase_ == OpOneofCase.Any) hash ^= Any.GetHashCode();
       if (opCase_ == OpOneofCase.None_) hash ^= None.GetHashCode();
-      if (opCase_ == OpOneofCase.Expr) hash ^= Expr.GetHashCode();
+      if (HasExpr) hash ^= Expr.GetHashCode();
       hash ^= (int) opCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -3571,7 +3694,7 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(26);
         output.WriteMessage(None);
       }
-      if (opCase_ == OpOneofCase.Expr) {
+      if (HasExpr) {
         output.WriteRawTag(34);
         output.WriteString(Expr);
       }
@@ -3597,7 +3720,7 @@ namespace Cerbos.Api.V1.Policy {
         output.WriteRawTag(26);
         output.WriteMessage(None);
       }
-      if (opCase_ == OpOneofCase.Expr) {
+      if (HasExpr) {
         output.WriteRawTag(34);
         output.WriteString(Expr);
       }
@@ -3620,7 +3743,7 @@ namespace Cerbos.Api.V1.Policy {
       if (opCase_ == OpOneofCase.None_) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(None);
       }
-      if (opCase_ == OpOneofCase.Expr) {
+      if (HasExpr) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Expr);
       }
       if (_unknownFields != null) {
@@ -3944,6 +4067,195 @@ namespace Cerbos.Api.V1.Policy {
 
   }
 
+  public sealed partial class Output : pb::IMessage<Output>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<Output> _parser = new pb::MessageParser<Output>(() => new Output());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<Output> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[10]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Output() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Output(Output other) : this() {
+      expr_ = other.expr_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Output Clone() {
+      return new Output(this);
+    }
+
+    /// <summary>Field number for the "expr" field.</summary>
+    public const int ExprFieldNumber = 1;
+    private string expr_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Expr {
+      get { return expr_; }
+      set {
+        expr_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as Output);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(Output other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Expr != other.Expr) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Expr.Length != 0) hash ^= Expr.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Expr.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Expr);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Expr.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Expr);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Expr.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Expr);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(Output other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Expr.Length != 0) {
+        Expr = other.Expr;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Expr = input.ReadString();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            Expr = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   public sealed partial class Schemas : pb::IMessage<Schemas>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3958,7 +4270,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[10]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[11]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4623,7 +4935,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[11]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[12]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4896,7 +5208,7 @@ namespace Cerbos.Api.V1.Policy {
           if (other == null) {
             return;
           }
-          principals_.Add(other.principals_);
+          principals_.MergeFrom(other.principals_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -5074,7 +5386,7 @@ namespace Cerbos.Api.V1.Policy {
           if (other == null) {
             return;
           }
-          resources_.Add(other.resources_);
+          resources_.MergeFrom(other.resources_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -5252,7 +5564,7 @@ namespace Cerbos.Api.V1.Policy {
           if (other == null) {
             return;
           }
-          auxData_.Add(other.auxData_);
+          auxData_.MergeFrom(other.auxData_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -5317,7 +5629,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[12]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[13]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5515,7 +5827,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[13]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[14]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5827,9 +6139,9 @@ namespace Cerbos.Api.V1.Policy {
         SkipReason = other.SkipReason;
       }
       tests_.Add(other.tests_);
-      principals_.Add(other.principals_);
-      resources_.Add(other.resources_);
-      auxData_.Add(other.auxData_);
+      principals_.MergeFrom(other.principals_);
+      resources_.MergeFrom(other.resources_);
+      auxData_.MergeFrom(other.auxData_);
       if (other.options_ != null) {
         if (options_ == null) {
           Options = new global::Cerbos.Api.V1.Policy.TestOptions();
@@ -5965,7 +6277,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[14]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6829,7 +7141,7 @@ namespace Cerbos.Api.V1.Policy {
           if (other.Resource.Length != 0) {
             Resource = other.Resource;
           }
-          actions_.Add(other.actions_);
+          actions_.MergeFrom(other.actions_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -6910,7 +7222,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[15]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7205,7 +7517,7 @@ namespace Cerbos.Api.V1.Policy {
         }
         Input.MergeFrom(other.Input);
       }
-      expected_.Add(other.expected_);
+      expected_.MergeFrom(other.expected_);
       if (other.options_ != null) {
         if (options_ == null) {
           Options = new global::Cerbos.Api.V1.Policy.TestOptions();
@@ -7608,7 +7920,7 @@ namespace Cerbos.Api.V1.Policy {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[16]; }
+      get { return global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor.MessageTypes[17]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9669,10 +9981,24 @@ namespace Cerbos.Api.V1.Policy {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public string Error {
-          get { return outcomeCase_ == OutcomeOneofCase.Error ? (string) outcome_ : ""; }
+          get { return HasError ? (string) outcome_ : ""; }
           set {
             outcome_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             outcomeCase_ = OutcomeOneofCase.Error;
+          }
+        }
+        /// <summary>Gets whether the "error" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasError {
+          get { return outcomeCase_ == OutcomeOneofCase.Error; }
+        }
+        /// <summary> Clears the value of the oneof if it's currently set to "error" </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearError() {
+          if (HasError) {
+            ClearOutcome();
           }
         }
 
@@ -9737,7 +10063,7 @@ namespace Cerbos.Api.V1.Policy {
           int hash = 1;
           if (Result != global::Cerbos.Api.V1.Policy.TestResults.Types.Result.Unspecified) hash ^= Result.GetHashCode();
           if (outcomeCase_ == OutcomeOneofCase.Failure) hash ^= Failure.GetHashCode();
-          if (outcomeCase_ == OutcomeOneofCase.Error) hash ^= Error.GetHashCode();
+          if (HasError) hash ^= Error.GetHashCode();
           hash ^= engineTrace_.GetHashCode();
           hash ^= (int) outcomeCase_;
           if (_unknownFields != null) {
@@ -9766,7 +10092,7 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteRawTag(18);
             output.WriteMessage(Failure);
           }
-          if (outcomeCase_ == OutcomeOneofCase.Error) {
+          if (HasError) {
             output.WriteRawTag(26);
             output.WriteString(Error);
           }
@@ -9789,7 +10115,7 @@ namespace Cerbos.Api.V1.Policy {
             output.WriteRawTag(18);
             output.WriteMessage(Failure);
           }
-          if (outcomeCase_ == OutcomeOneofCase.Error) {
+          if (HasError) {
             output.WriteRawTag(26);
             output.WriteString(Error);
           }
@@ -9810,7 +10136,7 @@ namespace Cerbos.Api.V1.Policy {
           if (outcomeCase_ == OutcomeOneofCase.Failure) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(Failure);
           }
-          if (outcomeCase_ == OutcomeOneofCase.Error) {
+          if (HasError) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Error);
           }
           size += engineTrace_.CalculateSize(_repeated_engineTrace_codec);

--- a/src/Sdk/Cerbos/Api/V1/Request/Request.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Request/Request.g.cs
@@ -213,40 +213,45 @@ namespace Cerbos.Api.V1.Request {
             "dHdlZW4gYSB0aW1lIHJhbmdlLiJACgRLaW5kEhQKEEtJTkRfVU5TUEVDSUZJ",
             "RUQQABIPCgtLSU5EX0FDQ0VTUxABEhEKDUtJTkRfREVDSVNJT04QAkINCgZm",
             "aWx0ZXISA/hCASIvChFTZXJ2ZXJJbmZvUmVxdWVzdDoakkEXChUyE1NlcnZl",
-            "ciBpbmZvIHJlcXVlc3QigQEKE0xpc3RQb2xpY2llc1JlcXVlc3QSTAoQaW5j",
+            "ciBpbmZvIHJlcXVlc3Qi9wIKE0xpc3RQb2xpY2llc1JlcXVlc3QSTAoQaW5j",
             "bHVkZV9kaXNhYmxlZBgBIAEoCEIhkkEbMhlJbmNsdWRlIGRpc2FibGVkIHBv",
-            "bGljaWVz4EEBUg9pbmNsdWRlRGlzYWJsZWQ6HJJBGQoXMhVMaXN0IHBvbGlj",
-            "aWVzIHJlcXVlc3QigwIKEEdldFBvbGljeVJlcXVlc3QS0wEKAmlkGAEgAygJ",
-            "QsIBkkGmATKHAUZvciBibG9iLCBkaXNrLCBnaXQgc3RvcmVzIHVzZSBmaWxl",
-            "IG5hbWUgKDxmaWxlbmFtZT4ueWFtbCkuIEZvciBteXNxbCwgcG9zdGdyZXMs",
-            "IHNxbGl0ZTMgdXNlIGlkICg8a2luZD4uPG5hbWU+Ljx2ZXJzaW9uPikgb2Yg",
+            "bGljaWVz4EEBUg9pbmNsdWRlRGlzYWJsZWQSTAoLbmFtZV9yZWdleHAYAiAB",
+            "KAlCK5JBJTIjRmlsdGVyIHBvbGljaWVzIGJ5IG5hbWUgd2l0aCByZWdleHDg",
+            "QQFSCm5hbWVSZWdleHASTwoMc2NvcGVfcmVnZXhwGAMgASgJQiySQSYyJEZp",
+            "bHRlciBwb2xpY2llcyBieSBzY29wZSB3aXRoIHJlZ2V4cOBBAVILc2NvcGVS",
+            "ZWdleHASVQoOdmVyc2lvbl9yZWdleHAYBCABKAlCLpJBKDImRmlsdGVyIHBv",
+            "bGljaWVzIGJ5IHZlcnNpb24gd2l0aCByZWdleHDgQQFSDXZlcnNpb25SZWdl",
+            "eHA6HJJBGQoXMhVMaXN0IHBvbGljaWVzIHJlcXVlc3QigwIKEEdldFBvbGlj",
+            "eVJlcXVlc3QS0wEKAmlkGAEgAygJQsIBkkGmATKHAUZvciBibG9iLCBkaXNr",
+            "LCBnaXQgc3RvcmVzIHVzZSBmaWxlIG5hbWUgKDxmaWxlbmFtZT4ueWFtbCku",
+            "IEZvciBteXNxbCwgcG9zdGdyZXMsIHNxbGl0ZTMgdXNlIGlkICg8a2luZD4u",
+            "PG5hbWU+Ljx2ZXJzaW9uPikgb2YgdGhlIHBvbGljeUoaInByaW5jaXBhbC5z",
+            "YXJhaC52ZGVmYXVsdCLgQQL6QhKSAQ8IARAZGAEiB3IFEAEYgApSAmlkOhmS",
+            "QRYKFDISR2V0IHBvbGljeSByZXF1ZXN0IqABChREaXNhYmxlUG9saWN5UmVx",
+            "dWVzdBJpCgJpZBgBIAMoCUJZkkE+MiBVbmlxdWUgaWRlbnRpZmllciBmb3Ig",
             "dGhlIHBvbGljeUoaInByaW5jaXBhbC5zYXJhaC52ZGVmYXVsdCLgQQL6QhKS",
-            "AQ8IARAZGAEiB3IFEAEYgApSAmlkOhmSQRYKFDISR2V0IHBvbGljeSByZXF1",
-            "ZXN0IqABChREaXNhYmxlUG9saWN5UmVxdWVzdBJpCgJpZBgBIAMoCUJZkkE+",
-            "MiBVbmlxdWUgaWRlbnRpZmllciBmb3IgdGhlIHBvbGljeUoaInByaW5jaXBh",
-            "bC5zYXJhaC52ZGVmYXVsdCLgQQL6QhKSAQ8IARAZGAEiB3IFEAEYgApSAmlk",
-            "Oh2SQRoKGDIWRGlzYWJsZSBwb2xpY3kgcmVxdWVzdCKeAQoTRW5hYmxlUG9s",
-            "aWN5UmVxdWVzdBJpCgJpZBgBIAMoCUJZkkE+MiBVbmlxdWUgaWRlbnRpZmll",
-            "ciBmb3IgdGhlIHBvbGljeUoaInByaW5jaXBhbC5zYXJhaC52ZGVmYXVsdCLg",
-            "QQL6QhKSAQ8IARAZGAEiB3IFEAEYgApSAmlkOhySQRkKFzIVRW5hYmxlIHBv",
-            "bGljeSByZXF1ZXN0IpoBChhBZGRPclVwZGF0ZVNjaGVtYVJlcXVlc3QSXAoH",
-            "c2NoZW1hcxgBIAMoCzIYLmNlcmJvcy5zY2hlbWEudjEuU2NoZW1hQiiSQRgy",
-            "EExpc3Qgb2Ygc2NoZW1hcy6gAQqoAQHgQQL6QgeSAQQIARAKUgdzY2hlbWFz",
-            "OiCSQR0KGzIZQWRkL3VwZGF0ZSBzY2hlbWEgcmVxdWVzdCI0ChJMaXN0U2No",
-            "ZW1hc1JlcXVlc3Q6HpJBGwoZMhdMaXN0IHNjaGVtYSBpZHMgcmVxdWVzdCKR",
-            "AQoQR2V0U2NoZW1hUmVxdWVzdBJfCgJpZBgBIAMoCUJPkkE0MiBVbmlxdWUg",
-            "aWRlbnRpZmllciBmb3IgdGhlIHNjaGVtYUoQInByaW5jaXBhbC5qc29uIuBB",
-            "AvpCEpIBDwgBEBkYASIHcgUQARj/AVICaWQ6HJJBGQoXMhVHZXQgc2NoZW1h",
-            "KHMpIHJlcXVlc3QilwEKE0RlbGV0ZVNjaGVtYVJlcXVlc3QSXwoCaWQYASAD",
-            "KAlCT5JBNDIgVW5pcXVlIGlkZW50aWZpZXIgZm9yIHRoZSBzY2hlbWFKECJw",
-            "cmluY2lwYWwuanNvbiLgQQL6QhKSAQ8IARAZGAEiB3IFEAEY/wFSAmlkOh+S",
-            "QRwKGjIYRGVsZXRlIHNjaGVtYShzKSByZXF1ZXN0InkKElJlbG9hZFN0b3Jl",
-            "UmVxdWVzdBJGCgR3YWl0GAEgASgIQjKSQSwyKldhaXQgdW50aWwgdGhlIHJl",
-            "bG9hZGluZyBwcm9jZXNzIGZpbmFsaXplc+BBAVIEd2FpdDobkkEYChYyFFJl",
-            "bG9hZCBzdG9yZSByZXF1ZXN0QnMKGWRldi5jZXJib3MuYXBpLnYxLnJlcXVl",
-            "c3RaPmdpdGh1Yi5jb20vY2VyYm9zL2NlcmJvcy9hcGkvZ2VucGIvY2VyYm9z",
-            "L3JlcXVlc3QvdjE7cmVxdWVzdHYxqgIVQ2VyYm9zLkFwaS5WMS5SZXF1ZXN0",
-            "YgZwcm90bzM="));
+            "AQ8IARAZGAEiB3IFEAEYgApSAmlkOh2SQRoKGDIWRGlzYWJsZSBwb2xpY3kg",
+            "cmVxdWVzdCKeAQoTRW5hYmxlUG9saWN5UmVxdWVzdBJpCgJpZBgBIAMoCUJZ",
+            "kkE+MiBVbmlxdWUgaWRlbnRpZmllciBmb3IgdGhlIHBvbGljeUoaInByaW5j",
+            "aXBhbC5zYXJhaC52ZGVmYXVsdCLgQQL6QhKSAQ8IARAZGAEiB3IFEAEYgApS",
+            "AmlkOhySQRkKFzIVRW5hYmxlIHBvbGljeSByZXF1ZXN0IpoBChhBZGRPclVw",
+            "ZGF0ZVNjaGVtYVJlcXVlc3QSXAoHc2NoZW1hcxgBIAMoCzIYLmNlcmJvcy5z",
+            "Y2hlbWEudjEuU2NoZW1hQiiSQRgyEExpc3Qgb2Ygc2NoZW1hcy6gAQqoAQHg",
+            "QQL6QgeSAQQIARAKUgdzY2hlbWFzOiCSQR0KGzIZQWRkL3VwZGF0ZSBzY2hl",
+            "bWEgcmVxdWVzdCI0ChJMaXN0U2NoZW1hc1JlcXVlc3Q6HpJBGwoZMhdMaXN0",
+            "IHNjaGVtYSBpZHMgcmVxdWVzdCKRAQoQR2V0U2NoZW1hUmVxdWVzdBJfCgJp",
+            "ZBgBIAMoCUJPkkE0MiBVbmlxdWUgaWRlbnRpZmllciBmb3IgdGhlIHNjaGVt",
+            "YUoQInByaW5jaXBhbC5qc29uIuBBAvpCEpIBDwgBEBkYASIHcgUQARj/AVIC",
+            "aWQ6HJJBGQoXMhVHZXQgc2NoZW1hKHMpIHJlcXVlc3QilwEKE0RlbGV0ZVNj",
+            "aGVtYVJlcXVlc3QSXwoCaWQYASADKAlCT5JBNDIgVW5pcXVlIGlkZW50aWZp",
+            "ZXIgZm9yIHRoZSBzY2hlbWFKECJwcmluY2lwYWwuanNvbiLgQQL6QhKSAQ8I",
+            "ARAZGAEiB3IFEAEY/wFSAmlkOh+SQRwKGjIYRGVsZXRlIHNjaGVtYShzKSBy",
+            "ZXF1ZXN0InkKElJlbG9hZFN0b3JlUmVxdWVzdBJGCgR3YWl0GAEgASgIQjKS",
+            "QSwyKldhaXQgdW50aWwgdGhlIHJlbG9hZGluZyBwcm9jZXNzIGZpbmFsaXpl",
+            "c+BBAVIEd2FpdDobkkEYChYyFFJlbG9hZCBzdG9yZSByZXF1ZXN0QnMKGWRl",
+            "di5jZXJib3MuYXBpLnYxLnJlcXVlc3RaPmdpdGh1Yi5jb20vY2VyYm9zL2Nl",
+            "cmJvcy9hcGkvZ2VucGIvY2VyYm9zL3JlcXVlc3QvdjE7cmVxdWVzdHYxqgIV",
+            "Q2VyYm9zLkFwaS5WMS5SZXF1ZXN0YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor, global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor, global::Cerbos.Api.V1.Schema.SchemaReflection.Descriptor, global::Google.Api.FieldBehaviorReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Grpc.Gateway.ProtocGenOpenapiv2.Options.AnnotationsReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -265,7 +270,7 @@ namespace Cerbos.Api.V1.Request {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.AddOrUpdatePolicyRequest), global::Cerbos.Api.V1.Request.AddOrUpdatePolicyRequest.Parser, new[]{ "Policies" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest), global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest.Parser, new[]{ "Kind", "Tail", "Between", "Since", "Lookup" }, new[]{ "Filter" }, new[]{ typeof(global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest.Types.Kind) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest.Types.TimeRange), global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest.Types.TimeRange.Parser, new[]{ "Start", "End" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.ServerInfoRequest), global::Cerbos.Api.V1.Request.ServerInfoRequest.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.ListPoliciesRequest), global::Cerbos.Api.V1.Request.ListPoliciesRequest.Parser, new[]{ "IncludeDisabled" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.ListPoliciesRequest), global::Cerbos.Api.V1.Request.ListPoliciesRequest.Parser, new[]{ "IncludeDisabled", "NameRegexp", "ScopeRegexp", "VersionRegexp" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.GetPolicyRequest), global::Cerbos.Api.V1.Request.GetPolicyRequest.Parser, new[]{ "Id" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.DisablePolicyRequest), global::Cerbos.Api.V1.Request.DisablePolicyRequest.Parser, new[]{ "Id" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Request.EnablePolicyRequest), global::Cerbos.Api.V1.Request.EnablePolicyRequest.Parser, new[]{ "Id" }, null, null, null, null),
@@ -5636,6 +5641,9 @@ namespace Cerbos.Api.V1.Request {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ListPoliciesRequest(ListPoliciesRequest other) : this() {
       includeDisabled_ = other.includeDisabled_;
+      nameRegexp_ = other.nameRegexp_;
+      scopeRegexp_ = other.scopeRegexp_;
+      versionRegexp_ = other.versionRegexp_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -5657,6 +5665,42 @@ namespace Cerbos.Api.V1.Request {
       }
     }
 
+    /// <summary>Field number for the "name_regexp" field.</summary>
+    public const int NameRegexpFieldNumber = 2;
+    private string nameRegexp_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string NameRegexp {
+      get { return nameRegexp_; }
+      set {
+        nameRegexp_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "scope_regexp" field.</summary>
+    public const int ScopeRegexpFieldNumber = 3;
+    private string scopeRegexp_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ScopeRegexp {
+      get { return scopeRegexp_; }
+      set {
+        scopeRegexp_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "version_regexp" field.</summary>
+    public const int VersionRegexpFieldNumber = 4;
+    private string versionRegexp_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string VersionRegexp {
+      get { return versionRegexp_; }
+      set {
+        versionRegexp_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -5673,6 +5717,9 @@ namespace Cerbos.Api.V1.Request {
         return true;
       }
       if (IncludeDisabled != other.IncludeDisabled) return false;
+      if (NameRegexp != other.NameRegexp) return false;
+      if (ScopeRegexp != other.ScopeRegexp) return false;
+      if (VersionRegexp != other.VersionRegexp) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -5681,6 +5728,9 @@ namespace Cerbos.Api.V1.Request {
     public override int GetHashCode() {
       int hash = 1;
       if (IncludeDisabled != false) hash ^= IncludeDisabled.GetHashCode();
+      if (NameRegexp.Length != 0) hash ^= NameRegexp.GetHashCode();
+      if (ScopeRegexp.Length != 0) hash ^= ScopeRegexp.GetHashCode();
+      if (VersionRegexp.Length != 0) hash ^= VersionRegexp.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -5703,6 +5753,18 @@ namespace Cerbos.Api.V1.Request {
         output.WriteRawTag(8);
         output.WriteBool(IncludeDisabled);
       }
+      if (NameRegexp.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(NameRegexp);
+      }
+      if (ScopeRegexp.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(ScopeRegexp);
+      }
+      if (VersionRegexp.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(VersionRegexp);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -5717,6 +5779,18 @@ namespace Cerbos.Api.V1.Request {
         output.WriteRawTag(8);
         output.WriteBool(IncludeDisabled);
       }
+      if (NameRegexp.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(NameRegexp);
+      }
+      if (ScopeRegexp.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(ScopeRegexp);
+      }
+      if (VersionRegexp.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(VersionRegexp);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -5729,6 +5803,15 @@ namespace Cerbos.Api.V1.Request {
       int size = 0;
       if (IncludeDisabled != false) {
         size += 1 + 1;
+      }
+      if (NameRegexp.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(NameRegexp);
+      }
+      if (ScopeRegexp.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ScopeRegexp);
+      }
+      if (VersionRegexp.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(VersionRegexp);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -5744,6 +5827,15 @@ namespace Cerbos.Api.V1.Request {
       }
       if (other.IncludeDisabled != false) {
         IncludeDisabled = other.IncludeDisabled;
+      }
+      if (other.NameRegexp.Length != 0) {
+        NameRegexp = other.NameRegexp;
+      }
+      if (other.ScopeRegexp.Length != 0) {
+        ScopeRegexp = other.ScopeRegexp;
+      }
+      if (other.VersionRegexp.Length != 0) {
+        VersionRegexp = other.VersionRegexp;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -5764,6 +5856,18 @@ namespace Cerbos.Api.V1.Request {
             IncludeDisabled = input.ReadBool();
             break;
           }
+          case 18: {
+            NameRegexp = input.ReadString();
+            break;
+          }
+          case 26: {
+            ScopeRegexp = input.ReadString();
+            break;
+          }
+          case 34: {
+            VersionRegexp = input.ReadString();
+            break;
+          }
         }
       }
     #endif
@@ -5781,6 +5885,18 @@ namespace Cerbos.Api.V1.Request {
             break;
           case 8: {
             IncludeDisabled = input.ReadBool();
+            break;
+          }
+          case 18: {
+            NameRegexp = input.ReadString();
+            break;
+          }
+          case 26: {
+            ScopeRegexp = input.ReadString();
+            break;
+          }
+          case 34: {
+            VersionRegexp = input.ReadString();
             break;
           }
         }

--- a/src/Sdk/Cerbos/Api/V1/Request/Request.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Request/Request.g.cs
@@ -1290,7 +1290,7 @@ namespace Cerbos.Api.V1.Request {
       if (other.PolicyVersion.Length != 0) {
         PolicyVersion = other.PolicyVersion;
       }
-      instances_.Add(other.instances_);
+      instances_.MergeFrom(other.instances_);
       if (other.Scope.Length != 0) {
         Scope = other.Scope;
       }
@@ -1495,7 +1495,7 @@ namespace Cerbos.Api.V1.Request {
       if (other == null) {
         return;
       }
-      attr_.Add(other.attr_);
+      attr_.MergeFrom(other.attr_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -4837,10 +4837,24 @@ namespace Cerbos.Api.V1.Request {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public uint Tail {
-      get { return filterCase_ == FilterOneofCase.Tail ? (uint) filter_ : 0; }
+      get { return HasTail ? (uint) filter_ : 0; }
       set {
         filter_ = value;
         filterCase_ = FilterOneofCase.Tail;
+      }
+    }
+    /// <summary>Gets whether the "tail" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasTail {
+      get { return filterCase_ == FilterOneofCase.Tail; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "tail" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearTail() {
+      if (HasTail) {
+        ClearFilter();
       }
     }
 
@@ -4873,10 +4887,24 @@ namespace Cerbos.Api.V1.Request {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Lookup {
-      get { return filterCase_ == FilterOneofCase.Lookup ? (string) filter_ : ""; }
+      get { return HasLookup ? (string) filter_ : ""; }
       set {
         filter_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         filterCase_ = FilterOneofCase.Lookup;
+      }
+    }
+    /// <summary>Gets whether the "lookup" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasLookup {
+      get { return filterCase_ == FilterOneofCase.Lookup; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "lookup" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearLookup() {
+      if (HasLookup) {
+        ClearFilter();
       }
     }
 
@@ -4932,10 +4960,10 @@ namespace Cerbos.Api.V1.Request {
     public override int GetHashCode() {
       int hash = 1;
       if (Kind != global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest.Types.Kind.Unspecified) hash ^= Kind.GetHashCode();
-      if (filterCase_ == FilterOneofCase.Tail) hash ^= Tail.GetHashCode();
+      if (HasTail) hash ^= Tail.GetHashCode();
       if (filterCase_ == FilterOneofCase.Between) hash ^= Between.GetHashCode();
       if (filterCase_ == FilterOneofCase.Since) hash ^= Since.GetHashCode();
-      if (filterCase_ == FilterOneofCase.Lookup) hash ^= Lookup.GetHashCode();
+      if (HasLookup) hash ^= Lookup.GetHashCode();
       hash ^= (int) filterCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -4959,7 +4987,7 @@ namespace Cerbos.Api.V1.Request {
         output.WriteRawTag(8);
         output.WriteEnum((int) Kind);
       }
-      if (filterCase_ == FilterOneofCase.Tail) {
+      if (HasTail) {
         output.WriteRawTag(16);
         output.WriteUInt32(Tail);
       }
@@ -4971,7 +4999,7 @@ namespace Cerbos.Api.V1.Request {
         output.WriteRawTag(34);
         output.WriteMessage(Since);
       }
-      if (filterCase_ == FilterOneofCase.Lookup) {
+      if (HasLookup) {
         output.WriteRawTag(42);
         output.WriteString(Lookup);
       }
@@ -4989,7 +5017,7 @@ namespace Cerbos.Api.V1.Request {
         output.WriteRawTag(8);
         output.WriteEnum((int) Kind);
       }
-      if (filterCase_ == FilterOneofCase.Tail) {
+      if (HasTail) {
         output.WriteRawTag(16);
         output.WriteUInt32(Tail);
       }
@@ -5001,7 +5029,7 @@ namespace Cerbos.Api.V1.Request {
         output.WriteRawTag(34);
         output.WriteMessage(Since);
       }
-      if (filterCase_ == FilterOneofCase.Lookup) {
+      if (HasLookup) {
         output.WriteRawTag(42);
         output.WriteString(Lookup);
       }
@@ -5018,7 +5046,7 @@ namespace Cerbos.Api.V1.Request {
       if (Kind != global::Cerbos.Api.V1.Request.ListAuditLogEntriesRequest.Types.Kind.Unspecified) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Kind);
       }
-      if (filterCase_ == FilterOneofCase.Tail) {
+      if (HasTail) {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Tail);
       }
       if (filterCase_ == FilterOneofCase.Between) {
@@ -5027,7 +5055,7 @@ namespace Cerbos.Api.V1.Request {
       if (filterCase_ == FilterOneofCase.Since) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Since);
       }
-      if (filterCase_ == FilterOneofCase.Lookup) {
+      if (HasLookup) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Lookup);
       }
       if (_unknownFields != null) {

--- a/src/Sdk/Cerbos/Api/V1/Response/Response.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Response/Response.g.cs
@@ -217,65 +217,69 @@ namespace Cerbos.Api.V1.Response {
             "c3BvbnNlLnYxLlBsYXlncm91bmRUZXN0UmVzcG9uc2UuVGVzdFJlc3VsdHNI",
             "AFIHc3VjY2VzcxpGCgtUZXN0UmVzdWx0cxI3CgdyZXN1bHRzGAEgASgLMh0u",
             "Y2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0c1IHcmVzdWx0czofkkEcChoy",
-            "GFBsYXlncm91bmQgdGVzdCByZXNwb25zZUIJCgdvdXRjb21lIu8EChpQbGF5",
+            "GFBsYXlncm91bmQgdGVzdCByZXNwb25zZUIJCgdvdXRjb21lIrkGChpQbGF5",
             "Z3JvdW5kRXZhbHVhdGVSZXNwb25zZRIjCg1wbGF5Z3JvdW5kX2lkGAEgASgJ",
             "UgxwbGF5Z3JvdW5kSWQSQQoHZmFpbHVyZRgCIAEoCzIlLmNlcmJvcy5yZXNw",
             "b25zZS52MS5QbGF5Z3JvdW5kRmFpbHVyZUgAUgdmYWlsdXJlElkKB3N1Y2Nl",
             "c3MYAyABKAsyPS5jZXJib3MucmVzcG9uc2UudjEuUGxheWdyb3VuZEV2YWx1",
-            "YXRlUmVzcG9uc2UuRXZhbFJlc3VsdExpc3RIAFIHc3VjY2Vzcxr2AQoKRXZh",
+            "YXRlUmVzcG9uc2UuRXZhbFJlc3VsdExpc3RIAFIHc3VjY2Vzcxr+AQoKRXZh",
             "bFJlc3VsdBIWCgZhY3Rpb24YASABKAlSBmFjdGlvbhIwCgZlZmZlY3QYAiAB",
             "KA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVjdFIGZWZmZWN0EhYKBnBvbGlj",
-            "eRgDIAEoCVIGcG9saWN5EjYKF2VmZmVjdGl2ZV9kZXJpdmVkX3JvbGVzGAQg",
-            "AygJUhVlZmZlY3RpdmVEZXJpdmVkUm9sZXMSTgoRdmFsaWRhdGlvbl9lcnJv",
-            "cnMYBSADKAsyIS5jZXJib3Muc2NoZW1hLnYxLlZhbGlkYXRpb25FcnJvclIQ",
-            "dmFsaWRhdGlvbkVycm9ycxplCg5FdmFsUmVzdWx0TGlzdBJTCgdyZXN1bHRz",
-            "GAEgAygLMjkuY2VyYm9zLnJlc3BvbnNlLnYxLlBsYXlncm91bmRFdmFsdWF0",
-            "ZVJlc3BvbnNlLkV2YWxSZXN1bHRSB3Jlc3VsdHM6I5JBIAoeMhxQbGF5Z3Jv",
-            "dW5kIGV2YWx1YXRlIHJlc3BvbnNlQgkKB291dGNvbWUimwQKF1BsYXlncm91",
-            "bmRQcm94eVJlc3BvbnNlEiMKDXBsYXlncm91bmRfaWQYASABKAlSDHBsYXln",
-            "cm91bmRJZBJBCgdmYWlsdXJlGAIgASgLMiUuY2VyYm9zLnJlc3BvbnNlLnYx",
-            "LlBsYXlncm91bmRGYWlsdXJlSABSB2ZhaWx1cmUSXAoSY2hlY2tfcmVzb3Vy",
-            "Y2Vfc2V0GAMgASgLMiwuY2VyYm9zLnJlc3BvbnNlLnYxLkNoZWNrUmVzb3Vy",
-            "Y2VTZXRSZXNwb25zZUgAUhBjaGVja1Jlc291cmNlU2V0EmIKFGNoZWNrX3Jl",
-            "c291cmNlX2JhdGNoGAQgASgLMi4uY2VyYm9zLnJlc3BvbnNlLnYxLkNoZWNr",
-            "UmVzb3VyY2VCYXRjaFJlc3BvbnNlSABSEmNoZWNrUmVzb3VyY2VCYXRjaBJS",
-            "Cg5wbGFuX3Jlc291cmNlcxgFIAEoCzIpLmNlcmJvcy5yZXNwb25zZS52MS5Q",
-            "bGFuUmVzb3VyY2VzUmVzcG9uc2VIAFINcGxhblJlc291cmNlcxJVCg9jaGVj",
-            "a19yZXNvdXJjZXMYBiABKAsyKi5jZXJib3MucmVzcG9uc2UudjEuQ2hlY2tS",
-            "ZXNvdXJjZXNSZXNwb25zZUgAUg5jaGVja1Jlc291cmNlczogkkEdChsyGVBs",
-            "YXlncm91bmQgcHJveHkgcmVzcG9uc2VCCQoHb3V0Y29tZSJwChlBZGRPclVw",
-            "ZGF0ZVBvbGljeVJlc3BvbnNlEjAKB3N1Y2Nlc3MYASABKAsyFi5nb29nbGUu",
-            "cHJvdG9idWYuRW1wdHlSB3N1Y2Nlc3M6IZJBHgocMhpBZGQvdXBkYXRlIHBv",
-            "bGljeSByZXNwb25zZSLgAQobTGlzdEF1ZGl0TG9nRW50cmllc1Jlc3BvbnNl",
-            "EksKEGFjY2Vzc19sb2dfZW50cnkYASABKAsyHy5jZXJib3MuYXVkaXQudjEu",
-            "QWNjZXNzTG9nRW50cnlIAFIOYWNjZXNzTG9nRW50cnkSUQoSZGVjaXNpb25f",
-            "bG9nX2VudHJ5GAIgASgLMiEuY2VyYm9zLmF1ZGl0LnYxLkRlY2lzaW9uTG9n",
-            "RW50cnlIAFIQZGVjaXNpb25Mb2dFbnRyeToYkkEVChMyEUF1ZGl0IGxvZyBz",
-            "dHJlYW0uQgcKBWVudHJ5IoIBChJTZXJ2ZXJJbmZvUmVzcG9uc2USGAoHdmVy",
-            "c2lvbhgBIAEoCVIHdmVyc2lvbhIWCgZjb21taXQYAiABKAlSBmNvbW1pdBId",
-            "CgpidWlsZF9kYXRlGAMgASgJUglidWlsZERhdGU6G5JBGAoWMhRTZXJ2ZXIg",
-            "aW5mbyByZXNwb25zZSJqChRMaXN0UG9saWNpZXNSZXNwb25zZRIdCgpwb2xp",
-            "Y3lfaWRzGAEgAygJUglwb2xpY3lJZHM6M5JBMAouMixMaXN0IG9mIHBvbGlj",
-            "aWVzIHN0b3JlZCBpbiB0aGUgQ2VyYm9zIHNlcnZlciJlChFHZXRQb2xpY3lS",
-            "ZXNwb25zZRI0Cghwb2xpY2llcxgBIAMoCzIYLmNlcmJvcy5wb2xpY3kudjEu",
-            "UG9saWN5Ughwb2xpY2llczoakkEXChUyE0dldCBwb2xpY3kgcmVzcG9uc2Ui",
-            "ZAoVRGlzYWJsZVBvbGljeVJlc3BvbnNlEisKEWRpc2FibGVkX3BvbGljaWVz",
-            "GAEgASgNUhBkaXNhYmxlZFBvbGljaWVzOh6SQRsKGTIXRGlzYWJsZSBwb2xp",
-            "Y3kgcmVzcG9uc2UiYAoURW5hYmxlUG9saWN5UmVzcG9uc2USKQoQZW5hYmxl",
-            "ZF9wb2xpY2llcxgBIAEoDVIPZW5hYmxlZFBvbGljaWVzOh2SQRoKGDIWRW5h",
-            "YmxlIHBvbGljeSByZXNwb25zZSI+ChlBZGRPclVwZGF0ZVNjaGVtYVJlc3Bv",
-            "bnNlOiGSQR4KHDIaQWRkL3VwZGF0ZSBzY2hlbWEgcmVzcG9uc2UiVQoTTGlz",
-            "dFNjaGVtYXNSZXNwb25zZRIdCgpzY2hlbWFfaWRzGAEgAygJUglzY2hlbWFJ",
-            "ZHM6H5JBHAoaMhhMaXN0IHNjaGVtYSBpZHMgcmVzcG9uc2UiZgoRR2V0U2No",
-            "ZW1hUmVzcG9uc2USMgoHc2NoZW1hcxgBIAMoCzIYLmNlcmJvcy5zY2hlbWEu",
-            "djEuU2NoZW1hUgdzY2hlbWFzOh2SQRoKGDIWR2V0IHNjaGVtYShzKSByZXNw",
-            "b25zZSJhChREZWxldGVTY2hlbWFSZXNwb25zZRInCg9kZWxldGVkX3NjaGVt",
-            "YXMYASABKA1SDmRlbGV0ZWRTY2hlbWFzOiCSQR0KGzIZRGVsZXRlIHNjaGVt",
-            "YShzKSByZXNwb25zZSIzChNSZWxvYWRTdG9yZVJlc3BvbnNlOhySQRkKFzIV",
-            "UmVsb2FkIHN0b3JlIHJlc3BvbnNlQncKGmRldi5jZXJib3MuYXBpLnYxLnJl",
-            "c3BvbnNlWkBnaXRodWIuY29tL2NlcmJvcy9jZXJib3MvYXBpL2dlbnBiL2Nl",
-            "cmJvcy9yZXNwb25zZS92MTtyZXNwb25zZXYxqgIWQ2VyYm9zLkFwaS5WMS5S",
-            "ZXNwb25zZWIGcHJvdG8z"));
+            "eRgDIAEoCVIGcG9saWN5EjoKF2VmZmVjdGl2ZV9kZXJpdmVkX3JvbGVzGAQg",
+            "AygJQgIYAVIVZWZmZWN0aXZlRGVyaXZlZFJvbGVzElIKEXZhbGlkYXRpb25f",
+            "ZXJyb3JzGAUgAygLMiEuY2VyYm9zLnNjaGVtYS52MS5WYWxpZGF0aW9uRXJy",
+            "b3JCAhgBUhB2YWxpZGF0aW9uRXJyb3JzGqYCCg5FdmFsUmVzdWx0TGlzdBJT",
+            "CgdyZXN1bHRzGAEgAygLMjkuY2VyYm9zLnJlc3BvbnNlLnYxLlBsYXlncm91",
+            "bmRFdmFsdWF0ZVJlc3BvbnNlLkV2YWxSZXN1bHRSB3Jlc3VsdHMSNgoXZWZm",
+            "ZWN0aXZlX2Rlcml2ZWRfcm9sZXMYAiADKAlSFWVmZmVjdGl2ZURlcml2ZWRS",
+            "b2xlcxJOChF2YWxpZGF0aW9uX2Vycm9ycxgDIAMoCzIhLmNlcmJvcy5zY2hl",
+            "bWEudjEuVmFsaWRhdGlvbkVycm9yUhB2YWxpZGF0aW9uRXJyb3JzEjcKB291",
+            "dHB1dHMYBCADKAsyHS5jZXJib3MuZW5naW5lLnYxLk91dHB1dEVudHJ5Ugdv",
+            "dXRwdXRzOiOSQSAKHjIcUGxheWdyb3VuZCBldmFsdWF0ZSByZXNwb25zZUIJ",
+            "CgdvdXRjb21lIpsEChdQbGF5Z3JvdW5kUHJveHlSZXNwb25zZRIjCg1wbGF5",
+            "Z3JvdW5kX2lkGAEgASgJUgxwbGF5Z3JvdW5kSWQSQQoHZmFpbHVyZRgCIAEo",
+            "CzIlLmNlcmJvcy5yZXNwb25zZS52MS5QbGF5Z3JvdW5kRmFpbHVyZUgAUgdm",
+            "YWlsdXJlElwKEmNoZWNrX3Jlc291cmNlX3NldBgDIAEoCzIsLmNlcmJvcy5y",
+            "ZXNwb25zZS52MS5DaGVja1Jlc291cmNlU2V0UmVzcG9uc2VIAFIQY2hlY2tS",
+            "ZXNvdXJjZVNldBJiChRjaGVja19yZXNvdXJjZV9iYXRjaBgEIAEoCzIuLmNl",
+            "cmJvcy5yZXNwb25zZS52MS5DaGVja1Jlc291cmNlQmF0Y2hSZXNwb25zZUgA",
+            "UhJjaGVja1Jlc291cmNlQmF0Y2gSUgoOcGxhbl9yZXNvdXJjZXMYBSABKAsy",
+            "KS5jZXJib3MucmVzcG9uc2UudjEuUGxhblJlc291cmNlc1Jlc3BvbnNlSABS",
+            "DXBsYW5SZXNvdXJjZXMSVQoPY2hlY2tfcmVzb3VyY2VzGAYgASgLMiouY2Vy",
+            "Ym9zLnJlc3BvbnNlLnYxLkNoZWNrUmVzb3VyY2VzUmVzcG9uc2VIAFIOY2hl",
+            "Y2tSZXNvdXJjZXM6IJJBHQobMhlQbGF5Z3JvdW5kIHByb3h5IHJlc3BvbnNl",
+            "QgkKB291dGNvbWUicAoZQWRkT3JVcGRhdGVQb2xpY3lSZXNwb25zZRIwCgdz",
+            "dWNjZXNzGAEgASgLMhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5UgdzdWNjZXNz",
+            "OiGSQR4KHDIaQWRkL3VwZGF0ZSBwb2xpY3kgcmVzcG9uc2Ui4AEKG0xpc3RB",
+            "dWRpdExvZ0VudHJpZXNSZXNwb25zZRJLChBhY2Nlc3NfbG9nX2VudHJ5GAEg",
+            "ASgLMh8uY2VyYm9zLmF1ZGl0LnYxLkFjY2Vzc0xvZ0VudHJ5SABSDmFjY2Vz",
+            "c0xvZ0VudHJ5ElEKEmRlY2lzaW9uX2xvZ19lbnRyeRgCIAEoCzIhLmNlcmJv",
+            "cy5hdWRpdC52MS5EZWNpc2lvbkxvZ0VudHJ5SABSEGRlY2lzaW9uTG9nRW50",
+            "cnk6GJJBFQoTMhFBdWRpdCBsb2cgc3RyZWFtLkIHCgVlbnRyeSKCAQoSU2Vy",
+            "dmVySW5mb1Jlc3BvbnNlEhgKB3ZlcnNpb24YASABKAlSB3ZlcnNpb24SFgoG",
+            "Y29tbWl0GAIgASgJUgZjb21taXQSHQoKYnVpbGRfZGF0ZRgDIAEoCVIJYnVp",
+            "bGREYXRlOhuSQRgKFjIUU2VydmVyIGluZm8gcmVzcG9uc2UiagoUTGlzdFBv",
+            "bGljaWVzUmVzcG9uc2USHQoKcG9saWN5X2lkcxgBIAMoCVIJcG9saWN5SWRz",
+            "OjOSQTAKLjIsTGlzdCBvZiBwb2xpY2llcyBzdG9yZWQgaW4gdGhlIENlcmJv",
+            "cyBzZXJ2ZXIiZQoRR2V0UG9saWN5UmVzcG9uc2USNAoIcG9saWNpZXMYASAD",
+            "KAsyGC5jZXJib3MucG9saWN5LnYxLlBvbGljeVIIcG9saWNpZXM6GpJBFwoV",
+            "MhNHZXQgcG9saWN5IHJlc3BvbnNlImQKFURpc2FibGVQb2xpY3lSZXNwb25z",
+            "ZRIrChFkaXNhYmxlZF9wb2xpY2llcxgBIAEoDVIQZGlzYWJsZWRQb2xpY2ll",
+            "czoekkEbChkyF0Rpc2FibGUgcG9saWN5IHJlc3BvbnNlImAKFEVuYWJsZVBv",
+            "bGljeVJlc3BvbnNlEikKEGVuYWJsZWRfcG9saWNpZXMYASABKA1SD2VuYWJs",
+            "ZWRQb2xpY2llczodkkEaChgyFkVuYWJsZSBwb2xpY3kgcmVzcG9uc2UiPgoZ",
+            "QWRkT3JVcGRhdGVTY2hlbWFSZXNwb25zZTohkkEeChwyGkFkZC91cGRhdGUg",
+            "c2NoZW1hIHJlc3BvbnNlIlUKE0xpc3RTY2hlbWFzUmVzcG9uc2USHQoKc2No",
+            "ZW1hX2lkcxgBIAMoCVIJc2NoZW1hSWRzOh+SQRwKGjIYTGlzdCBzY2hlbWEg",
+            "aWRzIHJlc3BvbnNlImYKEUdldFNjaGVtYVJlc3BvbnNlEjIKB3NjaGVtYXMY",
+            "ASADKAsyGC5jZXJib3Muc2NoZW1hLnYxLlNjaGVtYVIHc2NoZW1hczodkkEa",
+            "ChgyFkdldCBzY2hlbWEocykgcmVzcG9uc2UiYQoURGVsZXRlU2NoZW1hUmVz",
+            "cG9uc2USJwoPZGVsZXRlZF9zY2hlbWFzGAEgASgNUg5kZWxldGVkU2NoZW1h",
+            "czogkkEdChsyGURlbGV0ZSBzY2hlbWEocykgcmVzcG9uc2UiMwoTUmVsb2Fk",
+            "U3RvcmVSZXNwb25zZTockkEZChcyFVJlbG9hZCBzdG9yZSByZXNwb25zZUJ3",
+            "ChpkZXYuY2VyYm9zLmFwaS52MS5yZXNwb25zZVpAZ2l0aHViLmNvbS9jZXJi",
+            "b3MvY2VyYm9zL2FwaS9nZW5wYi9jZXJib3MvcmVzcG9uc2UvdjE7cmVzcG9u",
+            "c2V2MaoCFkNlcmJvcy5BcGkuVjEuUmVzcG9uc2ViBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Audit.AuditReflection.Descriptor, global::Cerbos.Api.V1.Effect.EffectReflection.Descriptor, global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor, global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor, global::Cerbos.Api.V1.Schema.SchemaReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::Grpc.Gateway.ProtocGenOpenapiv2.Options.AnnotationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -294,7 +298,7 @@ namespace Cerbos.Api.V1.Response {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundValidateResponse), global::Cerbos.Api.V1.Response.PlaygroundValidateResponse.Parser, new[]{ "PlaygroundId", "Failure", "Success" }, new[]{ "Outcome" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundTestResponse), global::Cerbos.Api.V1.Response.PlaygroundTestResponse.Parser, new[]{ "PlaygroundId", "Failure", "Success" }, new[]{ "Outcome" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundTestResponse.Types.TestResults), global::Cerbos.Api.V1.Response.PlaygroundTestResponse.Types.TestResults.Parser, new[]{ "Results" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse), global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Parser, new[]{ "PlaygroundId", "Failure", "Success" }, new[]{ "Outcome" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Types.EvalResult), global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Types.EvalResult.Parser, new[]{ "Action", "Effect", "Policy", "EffectiveDerivedRoles", "ValidationErrors" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Types.EvalResultList), global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Types.EvalResultList.Parser, new[]{ "Results" }, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Types.EvalResultList), global::Cerbos.Api.V1.Response.PlaygroundEvaluateResponse.Types.EvalResultList.Parser, new[]{ "Results", "EffectiveDerivedRoles", "ValidationErrors", "Outputs" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.PlaygroundProxyResponse), global::Cerbos.Api.V1.Response.PlaygroundProxyResponse.Parser, new[]{ "PlaygroundId", "Failure", "CheckResourceSet", "CheckResourceBatch", "PlanResources", "CheckResources" }, new[]{ "Outcome" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.AddOrUpdatePolicyResponse), global::Cerbos.Api.V1.Response.AddOrUpdatePolicyResponse.Parser, new[]{ "Success" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.ListAuditLogEntriesResponse), global::Cerbos.Api.V1.Response.ListAuditLogEntriesResponse.Parser, new[]{ "AccessLogEntry", "DecisionLogEntry" }, new[]{ "Entry" }, null, null, null),
@@ -5492,6 +5496,7 @@ namespace Cerbos.Api.V1.Response {
         private static readonly pb::FieldCodec<string> _repeated_effectiveDerivedRoles_codec
             = pb::FieldCodec.ForString(34);
         private readonly pbc::RepeatedField<string> effectiveDerivedRoles_ = new pbc::RepeatedField<string>();
+        [global::System.ObsoleteAttribute]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public pbc::RepeatedField<string> EffectiveDerivedRoles {
@@ -5503,6 +5508,7 @@ namespace Cerbos.Api.V1.Response {
         private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Schema.ValidationError> _repeated_validationErrors_codec
             = pb::FieldCodec.ForMessage(42, global::Cerbos.Api.V1.Schema.ValidationError.Parser);
         private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Schema.ValidationError> validationErrors_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Schema.ValidationError>();
+        [global::System.ObsoleteAttribute]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public pbc::RepeatedField<global::Cerbos.Api.V1.Schema.ValidationError> ValidationErrors {
@@ -5753,6 +5759,9 @@ namespace Cerbos.Api.V1.Response {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public EvalResultList(EvalResultList other) : this() {
           results_ = other.results_.Clone();
+          effectiveDerivedRoles_ = other.effectiveDerivedRoles_.Clone();
+          validationErrors_ = other.validationErrors_.Clone();
+          outputs_ = other.outputs_.Clone();
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -5773,6 +5782,39 @@ namespace Cerbos.Api.V1.Response {
           get { return results_; }
         }
 
+        /// <summary>Field number for the "effective_derived_roles" field.</summary>
+        public const int EffectiveDerivedRolesFieldNumber = 2;
+        private static readonly pb::FieldCodec<string> _repeated_effectiveDerivedRoles_codec
+            = pb::FieldCodec.ForString(18);
+        private readonly pbc::RepeatedField<string> effectiveDerivedRoles_ = new pbc::RepeatedField<string>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<string> EffectiveDerivedRoles {
+          get { return effectiveDerivedRoles_; }
+        }
+
+        /// <summary>Field number for the "validation_errors" field.</summary>
+        public const int ValidationErrorsFieldNumber = 3;
+        private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Schema.ValidationError> _repeated_validationErrors_codec
+            = pb::FieldCodec.ForMessage(26, global::Cerbos.Api.V1.Schema.ValidationError.Parser);
+        private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Schema.ValidationError> validationErrors_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Schema.ValidationError>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<global::Cerbos.Api.V1.Schema.ValidationError> ValidationErrors {
+          get { return validationErrors_; }
+        }
+
+        /// <summary>Field number for the "outputs" field.</summary>
+        public const int OutputsFieldNumber = 4;
+        private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Engine.OutputEntry> _repeated_outputs_codec
+            = pb::FieldCodec.ForMessage(34, global::Cerbos.Api.V1.Engine.OutputEntry.Parser);
+        private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> outputs_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> Outputs {
+          get { return outputs_; }
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -5789,6 +5831,9 @@ namespace Cerbos.Api.V1.Response {
             return true;
           }
           if(!results_.Equals(other.results_)) return false;
+          if(!effectiveDerivedRoles_.Equals(other.effectiveDerivedRoles_)) return false;
+          if(!validationErrors_.Equals(other.validationErrors_)) return false;
+          if(!outputs_.Equals(other.outputs_)) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -5797,6 +5842,9 @@ namespace Cerbos.Api.V1.Response {
         public override int GetHashCode() {
           int hash = 1;
           hash ^= results_.GetHashCode();
+          hash ^= effectiveDerivedRoles_.GetHashCode();
+          hash ^= validationErrors_.GetHashCode();
+          hash ^= outputs_.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -5816,6 +5864,9 @@ namespace Cerbos.Api.V1.Response {
           output.WriteRawMessage(this);
         #else
           results_.WriteTo(output, _repeated_results_codec);
+          effectiveDerivedRoles_.WriteTo(output, _repeated_effectiveDerivedRoles_codec);
+          validationErrors_.WriteTo(output, _repeated_validationErrors_codec);
+          outputs_.WriteTo(output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -5827,6 +5878,9 @@ namespace Cerbos.Api.V1.Response {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
           results_.WriteTo(ref output, _repeated_results_codec);
+          effectiveDerivedRoles_.WriteTo(ref output, _repeated_effectiveDerivedRoles_codec);
+          validationErrors_.WriteTo(ref output, _repeated_validationErrors_codec);
+          outputs_.WriteTo(ref output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -5838,6 +5892,9 @@ namespace Cerbos.Api.V1.Response {
         public int CalculateSize() {
           int size = 0;
           size += results_.CalculateSize(_repeated_results_codec);
+          size += effectiveDerivedRoles_.CalculateSize(_repeated_effectiveDerivedRoles_codec);
+          size += validationErrors_.CalculateSize(_repeated_validationErrors_codec);
+          size += outputs_.CalculateSize(_repeated_outputs_codec);
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
           }
@@ -5851,6 +5908,9 @@ namespace Cerbos.Api.V1.Response {
             return;
           }
           results_.Add(other.results_);
+          effectiveDerivedRoles_.Add(other.effectiveDerivedRoles_);
+          validationErrors_.Add(other.validationErrors_);
+          outputs_.Add(other.outputs_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -5870,6 +5930,18 @@ namespace Cerbos.Api.V1.Response {
                 results_.AddEntriesFrom(input, _repeated_results_codec);
                 break;
               }
+              case 18: {
+                effectiveDerivedRoles_.AddEntriesFrom(input, _repeated_effectiveDerivedRoles_codec);
+                break;
+              }
+              case 26: {
+                validationErrors_.AddEntriesFrom(input, _repeated_validationErrors_codec);
+                break;
+              }
+              case 34: {
+                outputs_.AddEntriesFrom(input, _repeated_outputs_codec);
+                break;
+              }
             }
           }
         #endif
@@ -5887,6 +5959,18 @@ namespace Cerbos.Api.V1.Response {
                 break;
               case 10: {
                 results_.AddEntriesFrom(ref input, _repeated_results_codec);
+                break;
+              }
+              case 18: {
+                effectiveDerivedRoles_.AddEntriesFrom(ref input, _repeated_effectiveDerivedRoles_codec);
+                break;
+              }
+              case 26: {
+                validationErrors_.AddEntriesFrom(ref input, _repeated_validationErrors_codec);
+                break;
+              }
+              case 34: {
+                outputs_.AddEntriesFrom(ref input, _repeated_outputs_codec);
                 break;
               }
             }

--- a/src/Sdk/Cerbos/Api/V1/Response/Response.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Response/Response.g.cs
@@ -135,7 +135,7 @@ namespace Cerbos.Api.V1.Response {
             "aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5Ei4KBXZhbHVlGAIgASgOMhgu",
             "Y2VyYm9zLmVmZmVjdC52MS5FZmZlY3RSBXZhbHVlOgI4ATo7kkE4CjYyNFBv",
             "bGljeSBldmFsdWF0aW9uIHJlc3BvbnNlIGZvciBhIGJhdGNoIG9mIHJlc291",
-            "cmNlcy4irRUKFkNoZWNrUmVzb3VyY2VzUmVzcG9uc2USbwoKcmVxdWVzdF9p",
+            "cmNlcy4iphcKFkNoZWNrUmVzb3VyY2VzUmVzcG9uc2USbwoKcmVxdWVzdF9p",
             "ZBgBIAEoCUJQkkFNMiNSZXF1ZXN0IElEIHByb3ZpZGVkIGluIHRoZSByZXF1",
             "ZXN0LkomImMyZGIxN2I4LTRmOWYtNGZiMS1hY2ZkLTkxNjJhMDJiZTQyYiJS",
             "CXJlcXVlc3RJZBLjAQoHcmVzdWx0cxgCIAMoCzI2LmNlcmJvcy5yZXNwb25z",
@@ -143,7 +143,7 @@ namespace Cerbos.Api.V1.Response {
             "ATIYUmVzdWx0IGZvciBlYWNoIHJlc291cmNlSnBbeyJyZXNvdXJjZSI6IHsi",
             "SWQiOiJYWDEyNSIsICJraW5kIjoiYWxidW06b2JqZWN0In0sICJhY3Rpb25z",
             "Ijp7InZpZXciOiJFRkZFQ1RfQUxMT1ciLCJjb21tZW50IjoiRUZGRUNUX0RF",
-            "TlkifX1dUgdyZXN1bHRzGocSCgtSZXN1bHRFbnRyeRJbCghyZXNvdXJjZRgB",
+            "TlkifX1dUgdyZXN1bHRzGoAUCgtSZXN1bHRFbnRyeRJbCghyZXNvdXJjZRgB",
             "IAEoCzI/LmNlcmJvcy5yZXNwb25zZS52MS5DaGVja1Jlc291cmNlc1Jlc3Bv",
             "bnNlLlJlc3VsdEVudHJ5LlJlc291cmNlUghyZXNvdXJjZRKhAQoHYWN0aW9u",
             "cxgCIAMoCzJDLmNlcmJvcy5yZXNwb25zZS52MS5DaGVja1Jlc291cmNlc1Jl",
@@ -158,118 +158,124 @@ namespace Cerbos.Api.V1.Response {
             "eSBldmFsdWF0aW9uSp0BeyJhY3Rpb25zIjogeyJ2aWV3OioiOnsibWF0Y2hl",
             "ZF9wb2xpY3kiOiAiYWxidW06b2JqZWN0OmRlZmF1bHQifSwiY29tbWVudCI6",
             "eyJtYXRjaGVkX3BvbGljeSI6ICJhbGJ1bTpvYmplY3Q6ZGVmYXVsdCJ9fSwg",
-            "ImVmZmVjdGl2ZV9kZXJpdmVkX3JvbGVzIjogWyJvd25lciJdfVIEbWV0YRr/",
-            "BAoIUmVzb3VyY2USOQoCaWQYASABKAlCKZJBJjIbSUQgb2YgdGhlIHJlc291",
-            "cmNlIGluc3RhbmNlSgciWFgxMjUiUgJpZBKTAQoEa2luZBgCIAEoCUJ/kkF8",
-            "MilOYW1lIG9mIHRoZSByZXNvdXJjZSBraW5kIGJlaW5nIGFjY2Vzc2VkLkoN",
-            "ImFsYnVtOnBob3RvIooBP15bWzphbHBoYTpdXVtbOndvcmQ6XVxAXC5cLV0q",
-            "KFw6W1s6YWxwaGE6XV1bWzp3b3JkOl1cQFwuXC1dKikqJFIEa2luZBLFAQoO",
-            "cG9saWN5X3ZlcnNpb24YAyABKAlCnQGSQZkBMnxUaGUgcG9saWN5IHZlcnNp",
-            "b24gdG8gdXNlIHRvIGV2YWx1YXRlIHRoaXMgcmVxdWVzdC4gSWYgbm90IHNw",
-            "ZWNpZmllZCwgd2lsbCBkZWZhdWx0IHRvIHRoZSBzZXJ2ZXItY29uZmlndXJl",
-            "ZCBkZWZhdWx0IHZlcnNpb24uSgkiZGVmYXVsdCKKAQ1eW1s6d29yZDpdXSok",
-            "Ug1wb2xpY3lWZXJzaW9uEtkBCgVzY29wZRgEIAEoCULCAZJBvgEyfUEgZG90",
-            "LXNlcGFyYXRlZCBzY29wZSB0aGF0IGRlc2NyaWJlcyB0aGUgaGllcmFyY2h5",
-            "IHRoaXMgcmVzb3VyY2UgYmVsb25ncyB0by4gVGhpcyBpcyB1c2VkIGZvciBk",
-            "ZXRlcm1pbmluZyBwb2xpY3kgaW5oZXJpdGFuY2UuSgsiYWNtZS5jb3JwIooB",
-            "L14oW1s6YWxudW06XV1bWzp3b3JkOl1cLV0qKFwuW1s6d29yZDpdXC1dKikq",
-            "KSokUgVzY29wZRrwBgoETWV0YRKmAgoHYWN0aW9ucxgBIAMoCzJILmNlcmJv",
-            "cy5yZXNwb25zZS52MS5DaGVja1Jlc291cmNlc1Jlc3BvbnNlLlJlc3VsdEVu",
-            "dHJ5Lk1ldGEuQWN0aW9uc0VudHJ5QsEBkkG9ATJPTWV0YWRhdGEgYWJvdXQg",
-            "dGhlIGVmZmVjdCBjYWxjdWxhdGVkIGZvciBlYWNoIGFjdGlvbiBvbiB0aGlz",
-            "IHJlc291cmNlIGluc3RhbmNlLkpqeyJ2aWV3OioiOnsibWF0Y2hlZF9wb2xp",
-            "Y3kiOiAiYWxidW06b2JqZWN0OmRlZmF1bHQifSwiY29tbWVudCI6eyJtYXRj",
-            "aGVkX3BvbGljeSI6ICJhbGJ1bTpvYmplY3Q6ZGVmYXVsdCJ9fVIHYWN0aW9u",
-            "cxKDAQoXZWZmZWN0aXZlX2Rlcml2ZWRfcm9sZXMYAiADKAlCS5JBSDI7RGVy",
-            "aXZlZCByb2xlcyB0aGF0IHdlcmUgZWZmZWN0aXZlIGR1cmluZyBwb2xpY3kg",
-            "ZXZhbHVhdGlvbi5KCVsib3duZXIiXVIVZWZmZWN0aXZlRGVyaXZlZFJvbGVz",
-            "GogCCgpFZmZlY3RNZXRhEm8KDm1hdGNoZWRfcG9saWN5GAEgASgJQkiSQUUy",
-            "K1BvbGljeSB0aGF0IG1hdGNoZWQgdG8gcHJvZHVjZSB0aGlzIGVmZmVjdC5K",
-            "FiJhbGJ1bTpvYmplY3Q6ZGVmYXVsdCJSDW1hdGNoZWRQb2xpY3kSbQoNbWF0",
-            "Y2hlZF9zY29wZRgCIAEoCUJIkkFFMjFQb2xpY3kgc2NvcGUgdGhhdCBtYXRj",
-            "aGVkIHRvIHByb2R1Y2UgdGhpcyBlZmZlY3QuShAiYWNtZS5jb3JwLmJhc2Ui",
-            "UgxtYXRjaGVkU2NvcGU6GpJBFwoVMhNOYW1lIG9mIHRoZSBhY3Rpb24uGoIB",
-            "CgxBY3Rpb25zRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSXAoFdmFsdWUYAiAB",
-            "KAsyRi5jZXJib3MucmVzcG9uc2UudjEuQ2hlY2tSZXNvdXJjZXNSZXNwb25z",
-            "ZS5SZXN1bHRFbnRyeS5NZXRhLkVmZmVjdE1ldGFSBXZhbHVlOgI4ATopkkEm",
-            "CiQyIk1ldGFkYXRhIGFib3V0IHJlcXVlc3QgZXZhbHVhdGlvbi4aVAoMQWN0",
-            "aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5Ei4KBXZhbHVlGAIgASgOMhgu",
-            "Y2VyYm9zLmVmZmVjdC52MS5FZmZlY3RSBXZhbHVlOgI4AToykkEvCi0yK1Jl",
-            "c3BvbnNlIGZyb20gdGhlIGNoZWNrIHJlc291cmNlcyBBUEkgY2FsbC4ipwEK",
-            "EVBsYXlncm91bmRGYWlsdXJlEkMKBmVycm9ycxgBIAMoCzIrLmNlcmJvcy5y",
-            "ZXNwb25zZS52MS5QbGF5Z3JvdW5kRmFpbHVyZS5FcnJvclIGZXJyb3JzGjEK",
-            "BUVycm9yEhIKBGZpbGUYASABKAlSBGZpbGUSFAoFZXJyb3IYAiABKAlSBWVy",
-            "cm9yOhqSQRcKFTITUGxheWdyb3VuZCByZXNwb25zZSLoAQoaUGxheWdyb3Vu",
-            "ZFZhbGlkYXRlUmVzcG9uc2USIwoNcGxheWdyb3VuZF9pZBgBIAEoCVIMcGxh",
-            "eWdyb3VuZElkEkEKB2ZhaWx1cmUYAiABKAsyJS5jZXJib3MucmVzcG9uc2Uu",
-            "djEuUGxheWdyb3VuZEZhaWx1cmVIAFIHZmFpbHVyZRIyCgdzdWNjZXNzGAMg",
-            "ASgLMhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5SABSB3N1Y2Nlc3M6I5JBIAoe",
-            "MhxQbGF5Z3JvdW5kIHZhbGlkYXRlIHJlc3BvbnNlQgkKB291dGNvbWUiyAIK",
-            "FlBsYXlncm91bmRUZXN0UmVzcG9uc2USIwoNcGxheWdyb3VuZF9pZBgBIAEo",
-            "CVIMcGxheWdyb3VuZElkEkEKB2ZhaWx1cmUYAiABKAsyJS5jZXJib3MucmVz",
-            "cG9uc2UudjEuUGxheWdyb3VuZEZhaWx1cmVIAFIHZmFpbHVyZRJSCgdzdWNj",
-            "ZXNzGAMgASgLMjYuY2VyYm9zLnJlc3BvbnNlLnYxLlBsYXlncm91bmRUZXN0",
-            "UmVzcG9uc2UuVGVzdFJlc3VsdHNIAFIHc3VjY2VzcxpGCgtUZXN0UmVzdWx0",
-            "cxI3CgdyZXN1bHRzGAEgASgLMh0uY2VyYm9zLnBvbGljeS52MS5UZXN0UmVz",
-            "dWx0c1IHcmVzdWx0czofkkEcChoyGFBsYXlncm91bmQgdGVzdCByZXNwb25z",
-            "ZUIJCgdvdXRjb21lIu8EChpQbGF5Z3JvdW5kRXZhbHVhdGVSZXNwb25zZRIj",
-            "Cg1wbGF5Z3JvdW5kX2lkGAEgASgJUgxwbGF5Z3JvdW5kSWQSQQoHZmFpbHVy",
-            "ZRgCIAEoCzIlLmNlcmJvcy5yZXNwb25zZS52MS5QbGF5Z3JvdW5kRmFpbHVy",
-            "ZUgAUgdmYWlsdXJlElkKB3N1Y2Nlc3MYAyABKAsyPS5jZXJib3MucmVzcG9u",
-            "c2UudjEuUGxheWdyb3VuZEV2YWx1YXRlUmVzcG9uc2UuRXZhbFJlc3VsdExp",
-            "c3RIAFIHc3VjY2Vzcxr2AQoKRXZhbFJlc3VsdBIWCgZhY3Rpb24YASABKAlS",
-            "BmFjdGlvbhIwCgZlZmZlY3QYAiABKA4yGC5jZXJib3MuZWZmZWN0LnYxLkVm",
-            "ZmVjdFIGZWZmZWN0EhYKBnBvbGljeRgDIAEoCVIGcG9saWN5EjYKF2VmZmVj",
-            "dGl2ZV9kZXJpdmVkX3JvbGVzGAQgAygJUhVlZmZlY3RpdmVEZXJpdmVkUm9s",
-            "ZXMSTgoRdmFsaWRhdGlvbl9lcnJvcnMYBSADKAsyIS5jZXJib3Muc2NoZW1h",
-            "LnYxLlZhbGlkYXRpb25FcnJvclIQdmFsaWRhdGlvbkVycm9ycxplCg5FdmFs",
-            "UmVzdWx0TGlzdBJTCgdyZXN1bHRzGAEgAygLMjkuY2VyYm9zLnJlc3BvbnNl",
-            "LnYxLlBsYXlncm91bmRFdmFsdWF0ZVJlc3BvbnNlLkV2YWxSZXN1bHRSB3Jl",
-            "c3VsdHM6I5JBIAoeMhxQbGF5Z3JvdW5kIGV2YWx1YXRlIHJlc3BvbnNlQgkK",
-            "B291dGNvbWUimwQKF1BsYXlncm91bmRQcm94eVJlc3BvbnNlEiMKDXBsYXln",
-            "cm91bmRfaWQYASABKAlSDHBsYXlncm91bmRJZBJBCgdmYWlsdXJlGAIgASgL",
-            "MiUuY2VyYm9zLnJlc3BvbnNlLnYxLlBsYXlncm91bmRGYWlsdXJlSABSB2Zh",
-            "aWx1cmUSXAoSY2hlY2tfcmVzb3VyY2Vfc2V0GAMgASgLMiwuY2VyYm9zLnJl",
-            "c3BvbnNlLnYxLkNoZWNrUmVzb3VyY2VTZXRSZXNwb25zZUgAUhBjaGVja1Jl",
-            "c291cmNlU2V0EmIKFGNoZWNrX3Jlc291cmNlX2JhdGNoGAQgASgLMi4uY2Vy",
-            "Ym9zLnJlc3BvbnNlLnYxLkNoZWNrUmVzb3VyY2VCYXRjaFJlc3BvbnNlSABS",
-            "EmNoZWNrUmVzb3VyY2VCYXRjaBJSCg5wbGFuX3Jlc291cmNlcxgFIAEoCzIp",
-            "LmNlcmJvcy5yZXNwb25zZS52MS5QbGFuUmVzb3VyY2VzUmVzcG9uc2VIAFIN",
-            "cGxhblJlc291cmNlcxJVCg9jaGVja19yZXNvdXJjZXMYBiABKAsyKi5jZXJi",
-            "b3MucmVzcG9uc2UudjEuQ2hlY2tSZXNvdXJjZXNSZXNwb25zZUgAUg5jaGVj",
-            "a1Jlc291cmNlczogkkEdChsyGVBsYXlncm91bmQgcHJveHkgcmVzcG9uc2VC",
-            "CQoHb3V0Y29tZSJwChlBZGRPclVwZGF0ZVBvbGljeVJlc3BvbnNlEjAKB3N1",
-            "Y2Nlc3MYASABKAsyFi5nb29nbGUucHJvdG9idWYuRW1wdHlSB3N1Y2Nlc3M6",
-            "IZJBHgocMhpBZGQvdXBkYXRlIHBvbGljeSByZXNwb25zZSLgAQobTGlzdEF1",
-            "ZGl0TG9nRW50cmllc1Jlc3BvbnNlEksKEGFjY2Vzc19sb2dfZW50cnkYASAB",
-            "KAsyHy5jZXJib3MuYXVkaXQudjEuQWNjZXNzTG9nRW50cnlIAFIOYWNjZXNz",
-            "TG9nRW50cnkSUQoSZGVjaXNpb25fbG9nX2VudHJ5GAIgASgLMiEuY2VyYm9z",
-            "LmF1ZGl0LnYxLkRlY2lzaW9uTG9nRW50cnlIAFIQZGVjaXNpb25Mb2dFbnRy",
-            "eToYkkEVChMyEUF1ZGl0IGxvZyBzdHJlYW0uQgcKBWVudHJ5IoIBChJTZXJ2",
-            "ZXJJbmZvUmVzcG9uc2USGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbhIWCgZj",
-            "b21taXQYAiABKAlSBmNvbW1pdBIdCgpidWlsZF9kYXRlGAMgASgJUglidWls",
-            "ZERhdGU6G5JBGAoWMhRTZXJ2ZXIgaW5mbyByZXNwb25zZSJqChRMaXN0UG9s",
-            "aWNpZXNSZXNwb25zZRIdCgpwb2xpY3lfaWRzGAEgAygJUglwb2xpY3lJZHM6",
-            "M5JBMAouMixMaXN0IG9mIHBvbGljaWVzIHN0b3JlZCBpbiB0aGUgQ2VyYm9z",
-            "IHNlcnZlciJlChFHZXRQb2xpY3lSZXNwb25zZRI0Cghwb2xpY2llcxgBIAMo",
-            "CzIYLmNlcmJvcy5wb2xpY3kudjEuUG9saWN5Ughwb2xpY2llczoakkEXChUy",
-            "E0dldCBwb2xpY3kgcmVzcG9uc2UiZAoVRGlzYWJsZVBvbGljeVJlc3BvbnNl",
-            "EisKEWRpc2FibGVkX3BvbGljaWVzGAEgASgNUhBkaXNhYmxlZFBvbGljaWVz",
-            "Oh6SQRsKGTIXRGlzYWJsZSBwb2xpY3kgcmVzcG9uc2UiYAoURW5hYmxlUG9s",
-            "aWN5UmVzcG9uc2USKQoQZW5hYmxlZF9wb2xpY2llcxgBIAEoDVIPZW5hYmxl",
-            "ZFBvbGljaWVzOh2SQRoKGDIWRW5hYmxlIHBvbGljeSByZXNwb25zZSI+ChlB",
-            "ZGRPclVwZGF0ZVNjaGVtYVJlc3BvbnNlOiGSQR4KHDIaQWRkL3VwZGF0ZSBz",
-            "Y2hlbWEgcmVzcG9uc2UiVQoTTGlzdFNjaGVtYXNSZXNwb25zZRIdCgpzY2hl",
-            "bWFfaWRzGAEgAygJUglzY2hlbWFJZHM6H5JBHAoaMhhMaXN0IHNjaGVtYSBp",
-            "ZHMgcmVzcG9uc2UiZgoRR2V0U2NoZW1hUmVzcG9uc2USMgoHc2NoZW1hcxgB",
-            "IAMoCzIYLmNlcmJvcy5zY2hlbWEudjEuU2NoZW1hUgdzY2hlbWFzOh2SQRoK",
-            "GDIWR2V0IHNjaGVtYShzKSByZXNwb25zZSJhChREZWxldGVTY2hlbWFSZXNw",
-            "b25zZRInCg9kZWxldGVkX3NjaGVtYXMYASABKA1SDmRlbGV0ZWRTY2hlbWFz",
-            "OiCSQR0KGzIZRGVsZXRlIHNjaGVtYShzKSByZXNwb25zZSIzChNSZWxvYWRT",
-            "dG9yZVJlc3BvbnNlOhySQRkKFzIVUmVsb2FkIHN0b3JlIHJlc3BvbnNlQncK",
-            "GmRldi5jZXJib3MuYXBpLnYxLnJlc3BvbnNlWkBnaXRodWIuY29tL2NlcmJv",
-            "cy9jZXJib3MvYXBpL2dlbnBiL2NlcmJvcy9yZXNwb25zZS92MTtyZXNwb25z",
-            "ZXYxqgIWQ2VyYm9zLkFwaS5WMS5SZXNwb25zZWIGcHJvdG8z"));
+            "ImVmZmVjdGl2ZV9kZXJpdmVkX3JvbGVzIjogWyJvd25lciJdfVIEbWV0YRL2",
+            "AQoHb3V0cHV0cxgFIAMoCzIdLmNlcmJvcy5lbmdpbmUudjEuT3V0cHV0RW50",
+            "cnlCvAGSQbgBMixPdXRwdXQgZm9yIGVhY2ggcnVsZSB3aXRoIG91dHB1dHMg",
+            "Y29uZmlndXJlZEqHAVt7InNyYyI6ICJyZXNvdXJjZS5leHBlbnNlLnYxL2Fj",
+            "bWUjcnVsZS0wMDEiLCAidmFsIjogInZpZXdfYWxsb3dlZDphbGljZSJ9LCB7",
+            "InNyYyI6ICJyZXNvdXJjZS5leHBlbnNlLnYxL2FjbWUjcnVsZS0wMDIiLCAi",
+            "dmFsIjogImZvbyJ9XVIHb3V0cHV0cxr/BAoIUmVzb3VyY2USOQoCaWQYASAB",
+            "KAlCKZJBJjIbSUQgb2YgdGhlIHJlc291cmNlIGluc3RhbmNlSgciWFgxMjUi",
+            "UgJpZBKTAQoEa2luZBgCIAEoCUJ/kkF8MilOYW1lIG9mIHRoZSByZXNvdXJj",
+            "ZSBraW5kIGJlaW5nIGFjY2Vzc2VkLkoNImFsYnVtOnBob3RvIooBP15bWzph",
+            "bHBoYTpdXVtbOndvcmQ6XVxAXC5cLV0qKFw6W1s6YWxwaGE6XV1bWzp3b3Jk",
+            "Ol1cQFwuXC1dKikqJFIEa2luZBLFAQoOcG9saWN5X3ZlcnNpb24YAyABKAlC",
+            "nQGSQZkBMnxUaGUgcG9saWN5IHZlcnNpb24gdG8gdXNlIHRvIGV2YWx1YXRl",
+            "IHRoaXMgcmVxdWVzdC4gSWYgbm90IHNwZWNpZmllZCwgd2lsbCBkZWZhdWx0",
+            "IHRvIHRoZSBzZXJ2ZXItY29uZmlndXJlZCBkZWZhdWx0IHZlcnNpb24uSgki",
+            "ZGVmYXVsdCKKAQ1eW1s6d29yZDpdXSokUg1wb2xpY3lWZXJzaW9uEtkBCgVz",
+            "Y29wZRgEIAEoCULCAZJBvgEyfUEgZG90LXNlcGFyYXRlZCBzY29wZSB0aGF0",
+            "IGRlc2NyaWJlcyB0aGUgaGllcmFyY2h5IHRoaXMgcmVzb3VyY2UgYmVsb25n",
+            "cyB0by4gVGhpcyBpcyB1c2VkIGZvciBkZXRlcm1pbmluZyBwb2xpY3kgaW5o",
+            "ZXJpdGFuY2UuSgsiYWNtZS5jb3JwIooBL14oW1s6YWxudW06XV1bWzp3b3Jk",
+            "Ol1cLV0qKFwuW1s6d29yZDpdXC1dKikqKSokUgVzY29wZRrwBgoETWV0YRKm",
+            "AgoHYWN0aW9ucxgBIAMoCzJILmNlcmJvcy5yZXNwb25zZS52MS5DaGVja1Jl",
+            "c291cmNlc1Jlc3BvbnNlLlJlc3VsdEVudHJ5Lk1ldGEuQWN0aW9uc0VudHJ5",
+            "QsEBkkG9ATJPTWV0YWRhdGEgYWJvdXQgdGhlIGVmZmVjdCBjYWxjdWxhdGVk",
+            "IGZvciBlYWNoIGFjdGlvbiBvbiB0aGlzIHJlc291cmNlIGluc3RhbmNlLkpq",
+            "eyJ2aWV3OioiOnsibWF0Y2hlZF9wb2xpY3kiOiAiYWxidW06b2JqZWN0OmRl",
+            "ZmF1bHQifSwiY29tbWVudCI6eyJtYXRjaGVkX3BvbGljeSI6ICJhbGJ1bTpv",
+            "YmplY3Q6ZGVmYXVsdCJ9fVIHYWN0aW9ucxKDAQoXZWZmZWN0aXZlX2Rlcml2",
+            "ZWRfcm9sZXMYAiADKAlCS5JBSDI7RGVyaXZlZCByb2xlcyB0aGF0IHdlcmUg",
+            "ZWZmZWN0aXZlIGR1cmluZyBwb2xpY3kgZXZhbHVhdGlvbi5KCVsib3duZXIi",
+            "XVIVZWZmZWN0aXZlRGVyaXZlZFJvbGVzGogCCgpFZmZlY3RNZXRhEm8KDm1h",
+            "dGNoZWRfcG9saWN5GAEgASgJQkiSQUUyK1BvbGljeSB0aGF0IG1hdGNoZWQg",
+            "dG8gcHJvZHVjZSB0aGlzIGVmZmVjdC5KFiJhbGJ1bTpvYmplY3Q6ZGVmYXVs",
+            "dCJSDW1hdGNoZWRQb2xpY3kSbQoNbWF0Y2hlZF9zY29wZRgCIAEoCUJIkkFF",
+            "MjFQb2xpY3kgc2NvcGUgdGhhdCBtYXRjaGVkIHRvIHByb2R1Y2UgdGhpcyBl",
+            "ZmZlY3QuShAiYWNtZS5jb3JwLmJhc2UiUgxtYXRjaGVkU2NvcGU6GpJBFwoV",
+            "MhNOYW1lIG9mIHRoZSBhY3Rpb24uGoIBCgxBY3Rpb25zRW50cnkSEAoDa2V5",
+            "GAEgASgJUgNrZXkSXAoFdmFsdWUYAiABKAsyRi5jZXJib3MucmVzcG9uc2Uu",
+            "djEuQ2hlY2tSZXNvdXJjZXNSZXNwb25zZS5SZXN1bHRFbnRyeS5NZXRhLkVm",
+            "ZmVjdE1ldGFSBXZhbHVlOgI4ATopkkEmCiQyIk1ldGFkYXRhIGFib3V0IHJl",
+            "cXVlc3QgZXZhbHVhdGlvbi4aVAoMQWN0aW9uc0VudHJ5EhAKA2tleRgBIAEo",
+            "CVIDa2V5Ei4KBXZhbHVlGAIgASgOMhguY2VyYm9zLmVmZmVjdC52MS5FZmZl",
+            "Y3RSBXZhbHVlOgI4AToykkEvCi0yK1Jlc3BvbnNlIGZyb20gdGhlIGNoZWNr",
+            "IHJlc291cmNlcyBBUEkgY2FsbC4ipwEKEVBsYXlncm91bmRGYWlsdXJlEkMK",
+            "BmVycm9ycxgBIAMoCzIrLmNlcmJvcy5yZXNwb25zZS52MS5QbGF5Z3JvdW5k",
+            "RmFpbHVyZS5FcnJvclIGZXJyb3JzGjEKBUVycm9yEhIKBGZpbGUYASABKAlS",
+            "BGZpbGUSFAoFZXJyb3IYAiABKAlSBWVycm9yOhqSQRcKFTITUGxheWdyb3Vu",
+            "ZCByZXNwb25zZSLoAQoaUGxheWdyb3VuZFZhbGlkYXRlUmVzcG9uc2USIwoN",
+            "cGxheWdyb3VuZF9pZBgBIAEoCVIMcGxheWdyb3VuZElkEkEKB2ZhaWx1cmUY",
+            "AiABKAsyJS5jZXJib3MucmVzcG9uc2UudjEuUGxheWdyb3VuZEZhaWx1cmVI",
+            "AFIHZmFpbHVyZRIyCgdzdWNjZXNzGAMgASgLMhYuZ29vZ2xlLnByb3RvYnVm",
+            "LkVtcHR5SABSB3N1Y2Nlc3M6I5JBIAoeMhxQbGF5Z3JvdW5kIHZhbGlkYXRl",
+            "IHJlc3BvbnNlQgkKB291dGNvbWUiyAIKFlBsYXlncm91bmRUZXN0UmVzcG9u",
+            "c2USIwoNcGxheWdyb3VuZF9pZBgBIAEoCVIMcGxheWdyb3VuZElkEkEKB2Zh",
+            "aWx1cmUYAiABKAsyJS5jZXJib3MucmVzcG9uc2UudjEuUGxheWdyb3VuZEZh",
+            "aWx1cmVIAFIHZmFpbHVyZRJSCgdzdWNjZXNzGAMgASgLMjYuY2VyYm9zLnJl",
+            "c3BvbnNlLnYxLlBsYXlncm91bmRUZXN0UmVzcG9uc2UuVGVzdFJlc3VsdHNI",
+            "AFIHc3VjY2VzcxpGCgtUZXN0UmVzdWx0cxI3CgdyZXN1bHRzGAEgASgLMh0u",
+            "Y2VyYm9zLnBvbGljeS52MS5UZXN0UmVzdWx0c1IHcmVzdWx0czofkkEcChoy",
+            "GFBsYXlncm91bmQgdGVzdCByZXNwb25zZUIJCgdvdXRjb21lIu8EChpQbGF5",
+            "Z3JvdW5kRXZhbHVhdGVSZXNwb25zZRIjCg1wbGF5Z3JvdW5kX2lkGAEgASgJ",
+            "UgxwbGF5Z3JvdW5kSWQSQQoHZmFpbHVyZRgCIAEoCzIlLmNlcmJvcy5yZXNw",
+            "b25zZS52MS5QbGF5Z3JvdW5kRmFpbHVyZUgAUgdmYWlsdXJlElkKB3N1Y2Nl",
+            "c3MYAyABKAsyPS5jZXJib3MucmVzcG9uc2UudjEuUGxheWdyb3VuZEV2YWx1",
+            "YXRlUmVzcG9uc2UuRXZhbFJlc3VsdExpc3RIAFIHc3VjY2Vzcxr2AQoKRXZh",
+            "bFJlc3VsdBIWCgZhY3Rpb24YASABKAlSBmFjdGlvbhIwCgZlZmZlY3QYAiAB",
+            "KA4yGC5jZXJib3MuZWZmZWN0LnYxLkVmZmVjdFIGZWZmZWN0EhYKBnBvbGlj",
+            "eRgDIAEoCVIGcG9saWN5EjYKF2VmZmVjdGl2ZV9kZXJpdmVkX3JvbGVzGAQg",
+            "AygJUhVlZmZlY3RpdmVEZXJpdmVkUm9sZXMSTgoRdmFsaWRhdGlvbl9lcnJv",
+            "cnMYBSADKAsyIS5jZXJib3Muc2NoZW1hLnYxLlZhbGlkYXRpb25FcnJvclIQ",
+            "dmFsaWRhdGlvbkVycm9ycxplCg5FdmFsUmVzdWx0TGlzdBJTCgdyZXN1bHRz",
+            "GAEgAygLMjkuY2VyYm9zLnJlc3BvbnNlLnYxLlBsYXlncm91bmRFdmFsdWF0",
+            "ZVJlc3BvbnNlLkV2YWxSZXN1bHRSB3Jlc3VsdHM6I5JBIAoeMhxQbGF5Z3Jv",
+            "dW5kIGV2YWx1YXRlIHJlc3BvbnNlQgkKB291dGNvbWUimwQKF1BsYXlncm91",
+            "bmRQcm94eVJlc3BvbnNlEiMKDXBsYXlncm91bmRfaWQYASABKAlSDHBsYXln",
+            "cm91bmRJZBJBCgdmYWlsdXJlGAIgASgLMiUuY2VyYm9zLnJlc3BvbnNlLnYx",
+            "LlBsYXlncm91bmRGYWlsdXJlSABSB2ZhaWx1cmUSXAoSY2hlY2tfcmVzb3Vy",
+            "Y2Vfc2V0GAMgASgLMiwuY2VyYm9zLnJlc3BvbnNlLnYxLkNoZWNrUmVzb3Vy",
+            "Y2VTZXRSZXNwb25zZUgAUhBjaGVja1Jlc291cmNlU2V0EmIKFGNoZWNrX3Jl",
+            "c291cmNlX2JhdGNoGAQgASgLMi4uY2VyYm9zLnJlc3BvbnNlLnYxLkNoZWNr",
+            "UmVzb3VyY2VCYXRjaFJlc3BvbnNlSABSEmNoZWNrUmVzb3VyY2VCYXRjaBJS",
+            "Cg5wbGFuX3Jlc291cmNlcxgFIAEoCzIpLmNlcmJvcy5yZXNwb25zZS52MS5Q",
+            "bGFuUmVzb3VyY2VzUmVzcG9uc2VIAFINcGxhblJlc291cmNlcxJVCg9jaGVj",
+            "a19yZXNvdXJjZXMYBiABKAsyKi5jZXJib3MucmVzcG9uc2UudjEuQ2hlY2tS",
+            "ZXNvdXJjZXNSZXNwb25zZUgAUg5jaGVja1Jlc291cmNlczogkkEdChsyGVBs",
+            "YXlncm91bmQgcHJveHkgcmVzcG9uc2VCCQoHb3V0Y29tZSJwChlBZGRPclVw",
+            "ZGF0ZVBvbGljeVJlc3BvbnNlEjAKB3N1Y2Nlc3MYASABKAsyFi5nb29nbGUu",
+            "cHJvdG9idWYuRW1wdHlSB3N1Y2Nlc3M6IZJBHgocMhpBZGQvdXBkYXRlIHBv",
+            "bGljeSByZXNwb25zZSLgAQobTGlzdEF1ZGl0TG9nRW50cmllc1Jlc3BvbnNl",
+            "EksKEGFjY2Vzc19sb2dfZW50cnkYASABKAsyHy5jZXJib3MuYXVkaXQudjEu",
+            "QWNjZXNzTG9nRW50cnlIAFIOYWNjZXNzTG9nRW50cnkSUQoSZGVjaXNpb25f",
+            "bG9nX2VudHJ5GAIgASgLMiEuY2VyYm9zLmF1ZGl0LnYxLkRlY2lzaW9uTG9n",
+            "RW50cnlIAFIQZGVjaXNpb25Mb2dFbnRyeToYkkEVChMyEUF1ZGl0IGxvZyBz",
+            "dHJlYW0uQgcKBWVudHJ5IoIBChJTZXJ2ZXJJbmZvUmVzcG9uc2USGAoHdmVy",
+            "c2lvbhgBIAEoCVIHdmVyc2lvbhIWCgZjb21taXQYAiABKAlSBmNvbW1pdBId",
+            "CgpidWlsZF9kYXRlGAMgASgJUglidWlsZERhdGU6G5JBGAoWMhRTZXJ2ZXIg",
+            "aW5mbyByZXNwb25zZSJqChRMaXN0UG9saWNpZXNSZXNwb25zZRIdCgpwb2xp",
+            "Y3lfaWRzGAEgAygJUglwb2xpY3lJZHM6M5JBMAouMixMaXN0IG9mIHBvbGlj",
+            "aWVzIHN0b3JlZCBpbiB0aGUgQ2VyYm9zIHNlcnZlciJlChFHZXRQb2xpY3lS",
+            "ZXNwb25zZRI0Cghwb2xpY2llcxgBIAMoCzIYLmNlcmJvcy5wb2xpY3kudjEu",
+            "UG9saWN5Ughwb2xpY2llczoakkEXChUyE0dldCBwb2xpY3kgcmVzcG9uc2Ui",
+            "ZAoVRGlzYWJsZVBvbGljeVJlc3BvbnNlEisKEWRpc2FibGVkX3BvbGljaWVz",
+            "GAEgASgNUhBkaXNhYmxlZFBvbGljaWVzOh6SQRsKGTIXRGlzYWJsZSBwb2xp",
+            "Y3kgcmVzcG9uc2UiYAoURW5hYmxlUG9saWN5UmVzcG9uc2USKQoQZW5hYmxl",
+            "ZF9wb2xpY2llcxgBIAEoDVIPZW5hYmxlZFBvbGljaWVzOh2SQRoKGDIWRW5h",
+            "YmxlIHBvbGljeSByZXNwb25zZSI+ChlBZGRPclVwZGF0ZVNjaGVtYVJlc3Bv",
+            "bnNlOiGSQR4KHDIaQWRkL3VwZGF0ZSBzY2hlbWEgcmVzcG9uc2UiVQoTTGlz",
+            "dFNjaGVtYXNSZXNwb25zZRIdCgpzY2hlbWFfaWRzGAEgAygJUglzY2hlbWFJ",
+            "ZHM6H5JBHAoaMhhMaXN0IHNjaGVtYSBpZHMgcmVzcG9uc2UiZgoRR2V0U2No",
+            "ZW1hUmVzcG9uc2USMgoHc2NoZW1hcxgBIAMoCzIYLmNlcmJvcy5zY2hlbWEu",
+            "djEuU2NoZW1hUgdzY2hlbWFzOh2SQRoKGDIWR2V0IHNjaGVtYShzKSByZXNw",
+            "b25zZSJhChREZWxldGVTY2hlbWFSZXNwb25zZRInCg9kZWxldGVkX3NjaGVt",
+            "YXMYASABKA1SDmRlbGV0ZWRTY2hlbWFzOiCSQR0KGzIZRGVsZXRlIHNjaGVt",
+            "YShzKSByZXNwb25zZSIzChNSZWxvYWRTdG9yZVJlc3BvbnNlOhySQRkKFzIV",
+            "UmVsb2FkIHN0b3JlIHJlc3BvbnNlQncKGmRldi5jZXJib3MuYXBpLnYxLnJl",
+            "c3BvbnNlWkBnaXRodWIuY29tL2NlcmJvcy9jZXJib3MvYXBpL2dlbnBiL2Nl",
+            "cmJvcy9yZXNwb25zZS92MTtyZXNwb25zZXYxqgIWQ2VyYm9zLkFwaS5WMS5S",
+            "ZXNwb25zZWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Cerbos.Api.V1.Audit.AuditReflection.Descriptor, global::Cerbos.Api.V1.Effect.EffectReflection.Descriptor, global::Cerbos.Api.V1.Engine.EngineReflection.Descriptor, global::Cerbos.Api.V1.Policy.PolicyReflection.Descriptor, global::Cerbos.Api.V1.Schema.SchemaReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::Grpc.Gateway.ProtocGenOpenapiv2.Options.AnnotationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -280,7 +286,7 @@ namespace Cerbos.Api.V1.Response {
             null, }),
             null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourceBatchResponse), global::Cerbos.Api.V1.Response.CheckResourceBatchResponse.Parser, new[]{ "RequestId", "Results" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourceBatchResponse.Types.ActionEffectMap), global::Cerbos.Api.V1.Response.CheckResourceBatchResponse.Types.ActionEffectMap.Parser, new[]{ "ResourceId", "Actions", "ValidationErrors" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, })}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Parser, new[]{ "RequestId", "Results" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Parser, new[]{ "Resource", "Actions", "ValidationErrors", "Meta" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Resource), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Resource.Parser, new[]{ "Id", "Kind", "PolicyVersion", "Scope" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Parser, new[]{ "RequestId", "Results" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Parser, new[]{ "Resource", "Actions", "ValidationErrors", "Meta", "Outputs" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Resource), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Resource.Parser, new[]{ "Id", "Kind", "PolicyVersion", "Scope" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Meta), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Meta.Parser, new[]{ "Actions", "EffectiveDerivedRoles" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Meta.Types.EffectMeta), global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Meta.Types.EffectMeta.Parser, new[]{ "MatchedPolicy", "MatchedScope" }, null, null, null, null),
             null, }),
             null, })}),
@@ -1150,7 +1156,7 @@ namespace Cerbos.Api.V1.Response {
       if (other.RequestId.Length != 0) {
         RequestId = other.RequestId;
       }
-      resourceInstances_.Add(other.resourceInstances_);
+      resourceInstances_.MergeFrom(other.resourceInstances_);
       if (other.meta_ != null) {
         if (meta_ == null) {
           Meta = new global::Cerbos.Api.V1.Response.CheckResourceSetResponse.Types.Meta();
@@ -1376,7 +1382,7 @@ namespace Cerbos.Api.V1.Response {
           if (other == null) {
             return;
           }
-          actions_.Add(other.actions_);
+          actions_.MergeFrom(other.actions_);
           validationErrors_.Add(other.validationErrors_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
@@ -1563,7 +1569,7 @@ namespace Cerbos.Api.V1.Response {
           if (other == null) {
             return;
           }
-          resourceInstances_.Add(other.resourceInstances_);
+          resourceInstances_.MergeFrom(other.resourceInstances_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -1987,7 +1993,7 @@ namespace Cerbos.Api.V1.Response {
               if (other == null) {
                 return;
               }
-              actions_.Add(other.actions_);
+              actions_.MergeFrom(other.actions_);
               effectiveDerivedRoles_.Add(other.effectiveDerivedRoles_);
               _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
             }
@@ -2451,7 +2457,7 @@ namespace Cerbos.Api.V1.Response {
           if (other.ResourceId.Length != 0) {
             ResourceId = other.ResourceId;
           }
-          actions_.Add(other.actions_);
+          actions_.MergeFrom(other.actions_);
           validationErrors_.Add(other.validationErrors_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
@@ -2775,6 +2781,7 @@ namespace Cerbos.Api.V1.Response {
           actions_ = other.actions_.Clone();
           validationErrors_ = other.validationErrors_.Clone();
           meta_ = other.meta_ != null ? other.meta_.Clone() : null;
+          outputs_ = other.outputs_.Clone();
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -2830,6 +2837,17 @@ namespace Cerbos.Api.V1.Response {
           }
         }
 
+        /// <summary>Field number for the "outputs" field.</summary>
+        public const int OutputsFieldNumber = 5;
+        private static readonly pb::FieldCodec<global::Cerbos.Api.V1.Engine.OutputEntry> _repeated_outputs_codec
+            = pb::FieldCodec.ForMessage(42, global::Cerbos.Api.V1.Engine.OutputEntry.Parser);
+        private readonly pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> outputs_ = new pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry>();
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<global::Cerbos.Api.V1.Engine.OutputEntry> Outputs {
+          get { return outputs_; }
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -2849,6 +2867,7 @@ namespace Cerbos.Api.V1.Response {
           if (!Actions.Equals(other.Actions)) return false;
           if(!validationErrors_.Equals(other.validationErrors_)) return false;
           if (!object.Equals(Meta, other.Meta)) return false;
+          if(!outputs_.Equals(other.outputs_)) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -2860,6 +2879,7 @@ namespace Cerbos.Api.V1.Response {
           hash ^= Actions.GetHashCode();
           hash ^= validationErrors_.GetHashCode();
           if (meta_ != null) hash ^= Meta.GetHashCode();
+          hash ^= outputs_.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -2888,6 +2908,7 @@ namespace Cerbos.Api.V1.Response {
             output.WriteRawTag(34);
             output.WriteMessage(Meta);
           }
+          outputs_.WriteTo(output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -2908,6 +2929,7 @@ namespace Cerbos.Api.V1.Response {
             output.WriteRawTag(34);
             output.WriteMessage(Meta);
           }
+          outputs_.WriteTo(ref output, _repeated_outputs_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -2926,6 +2948,7 @@ namespace Cerbos.Api.V1.Response {
           if (meta_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(Meta);
           }
+          size += outputs_.CalculateSize(_repeated_outputs_codec);
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
           }
@@ -2944,7 +2967,7 @@ namespace Cerbos.Api.V1.Response {
             }
             Resource.MergeFrom(other.Resource);
           }
-          actions_.Add(other.actions_);
+          actions_.MergeFrom(other.actions_);
           validationErrors_.Add(other.validationErrors_);
           if (other.meta_ != null) {
             if (meta_ == null) {
@@ -2952,6 +2975,7 @@ namespace Cerbos.Api.V1.Response {
             }
             Meta.MergeFrom(other.Meta);
           }
+          outputs_.Add(other.outputs_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -2989,6 +3013,10 @@ namespace Cerbos.Api.V1.Response {
                 input.ReadMessage(Meta);
                 break;
               }
+              case 42: {
+                outputs_.AddEntriesFrom(input, _repeated_outputs_codec);
+                break;
+              }
             }
           }
         #endif
@@ -3024,6 +3052,10 @@ namespace Cerbos.Api.V1.Response {
                   Meta = new global::Cerbos.Api.V1.Response.CheckResourcesResponse.Types.ResultEntry.Types.Meta();
                 }
                 input.ReadMessage(Meta);
+                break;
+              }
+              case 42: {
+                outputs_.AddEntriesFrom(ref input, _repeated_outputs_codec);
                 break;
               }
             }
@@ -3485,7 +3517,7 @@ namespace Cerbos.Api.V1.Response {
               if (other == null) {
                 return;
               }
-              actions_.Add(other.actions_);
+              actions_.MergeFrom(other.actions_);
               effectiveDerivedRoles_.Add(other.effectiveDerivedRoles_);
               _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
             }

--- a/src/Sdk/Cerbos/Api/V1/Telemetry/Telemetry.g.cs
+++ b/src/Sdk/Cerbos/Api/V1/Telemetry/Telemetry.g.cs
@@ -26,7 +26,7 @@ namespace Cerbos.Api.V1.Telemetry {
           string.Concat(
             "CiNjZXJib3MvdGVsZW1ldHJ5L3YxL3RlbGVtZXRyeS5wcm90bxITY2VyYm9z",
             "LnRlbGVtZXRyeS52MRoeZ29vZ2xlL3Byb3RvYnVmL2R1cmF0aW9uLnByb3Rv",
-            "Ir4RCgxTZXJ2ZXJMYXVuY2gSGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbhJA",
+            "IvYSCgxTZXJ2ZXJMYXVuY2gSGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbhJA",
             "CgZzb3VyY2UYAiABKAsyKC5jZXJib3MudGVsZW1ldHJ5LnYxLlNlcnZlckxh",
             "dW5jaC5Tb3VyY2VSBnNvdXJjZRJGCghmZWF0dXJlcxgDIAEoCzIqLmNlcmJv",
             "cy50ZWxlbWV0cnkudjEuU2VydmVyTGF1bmNoLkZlYXR1cmVzUghmZWF0dXJl",
@@ -38,7 +38,7 @@ namespace Cerbos.Api.V1.Telemetry {
             "dWxlQ2hlY2tzdW0aiQEKBlNvdXJjZRJACgZjZXJib3MYASABKAsyKC5jZXJi",
             "b3MudGVsZW1ldHJ5LnYxLlNlcnZlckxhdW5jaC5DZXJib3NSBmNlcmJvcxIO",
             "CgJvcxgCIAEoCVICb3MSEgoEYXJjaBgDIAEoCVIEYXJjaBIZCghudW1fY3B1",
-            "cxgEIAEoDVIHbnVtQ3B1cxrcBwoIRmVhdHVyZXMSRgoFYXVkaXQYASABKAsy",
+            "cxgEIAEoDVIHbnVtQ3B1cxqUCQoIRmVhdHVyZXMSRgoFYXVkaXQYASABKAsy",
             "MC5jZXJib3MudGVsZW1ldHJ5LnYxLlNlcnZlckxhdW5jaC5GZWF0dXJlcy5B",
             "dWRpdFIFYXVkaXQSSQoGc2NoZW1hGAIgASgLMjEuY2VyYm9zLnRlbGVtZXRy",
             "eS52MS5TZXJ2ZXJMYXVuY2guRmVhdHVyZXMuU2NoZW1hUgZzY2hlbWESUAoJ",
@@ -48,49 +48,53 @@ namespace Cerbos.Api.V1.Telemetry {
             "dXJlcy5TdG9yYWdlUgdzdG9yYWdlGjsKBUF1ZGl0EhgKB2VuYWJsZWQYASAB",
             "KAhSB2VuYWJsZWQSGAoHYmFja2VuZBgCIAEoCVIHYmFja2VuZBoqCgZTY2hl",
             "bWESIAoLZW5mb3JjZW1lbnQYASABKAlSC2VuZm9yY2VtZW50GiQKCEFkbWlu",
-            "QXBpEhgKB2VuYWJsZWQYASABKAhSB2VuYWJsZWQajQQKB1N0b3JhZ2USFgoG",
+            "QXBpEhgKB2VuYWJsZWQYASABKAhSB2VuYWJsZWQaxQUKB1N0b3JhZ2USFgoG",
             "ZHJpdmVyGAEgASgJUgZkcml2ZXISTQoEZGlzaxgCIAEoCzI3LmNlcmJvcy50",
             "ZWxlbWV0cnkudjEuU2VydmVyTGF1bmNoLkZlYXR1cmVzLlN0b3JhZ2UuRGlz",
             "a0gAUgRkaXNrEkoKA2dpdBgDIAEoCzI2LmNlcmJvcy50ZWxlbWV0cnkudjEu",
             "U2VydmVyTGF1bmNoLkZlYXR1cmVzLlN0b3JhZ2UuR2l0SABSA2dpdBJNCgRi",
             "bG9iGAQgASgLMjcuY2VyYm9zLnRlbGVtZXRyeS52MS5TZXJ2ZXJMYXVuY2gu",
-            "RmVhdHVyZXMuU3RvcmFnZS5CbG9iSABSBGJsb2IaHAoERGlzaxIUCgV3YXRj",
-            "aBgBIAEoCFIFd2F0Y2gadQoDR2l0EhoKCHByb3RvY29sGAEgASgJUghwcm90",
-            "b2NvbBISCgRhdXRoGAIgASgIUgRhdXRoEj4KDXBvbGxfaW50ZXJ2YWwYAyAB",
-            "KAsyGS5nb29nbGUucHJvdG9idWYuRHVyYXRpb25SDHBvbGxJbnRlcnZhbBpi",
-            "CgRCbG9iEhoKCHByb3ZpZGVyGAEgASgJUghwcm92aWRlchI+Cg1wb2xsX2lu",
-            "dGVydmFsGAIgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uUgxwb2xs",
-            "SW50ZXJ2YWxCBwoFc3RvcmUaswUKBVN0YXRzEkYKBnBvbGljeRgBIAEoCzIu",
-            "LmNlcmJvcy50ZWxlbWV0cnkudjEuU2VydmVyTGF1bmNoLlN0YXRzLlBvbGlj",
-            "eVIGcG9saWN5EkYKBnNjaGVtYRgCIAEoCzIuLmNlcmJvcy50ZWxlbWV0cnku",
-            "djEuU2VydmVyTGF1bmNoLlN0YXRzLlNjaGVtYVIGc2NoZW1hGvkDCgZQb2xp",
-            "Y3kSTwoFY291bnQYASADKAsyOS5jZXJib3MudGVsZW1ldHJ5LnYxLlNlcnZl",
-            "ckxhdW5jaC5TdGF0cy5Qb2xpY3kuQ291bnRFbnRyeVIFY291bnQSZgoOYXZn",
-            "X3J1bGVfY291bnQYAiADKAsyQC5jZXJib3MudGVsZW1ldHJ5LnYxLlNlcnZl",
-            "ckxhdW5jaC5TdGF0cy5Qb2xpY3kuQXZnUnVsZUNvdW50RW50cnlSDGF2Z1J1",
-            "bGVDb3VudBJ1ChNhdmdfY29uZGl0aW9uX2NvdW50GAMgAygLMkUuY2VyYm9z",
-            "LnRlbGVtZXRyeS52MS5TZXJ2ZXJMYXVuY2guU3RhdHMuUG9saWN5LkF2Z0Nv",
-            "bmRpdGlvbkNvdW50RW50cnlSEWF2Z0NvbmRpdGlvbkNvdW50GjgKCkNvdW50",
-            "RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKA1SBXZhbHVl",
-            "OgI4ARo/ChFBdmdSdWxlQ291bnRFbnRyeRIQCgNrZXkYASABKAlSA2tleRIU",
-            "CgV2YWx1ZRgCIAEoAVIFdmFsdWU6AjgBGkQKFkF2Z0NvbmRpdGlvbkNvdW50",
-            "RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAFSBXZhbHVl",
-            "OgI4ARoeCgZTY2hlbWESFAoFY291bnQYASABKA1SBWNvdW50IoABCgpTZXJ2",
-            "ZXJTdG9wEhgKB3ZlcnNpb24YASABKAlSB3ZlcnNpb24SMQoGdXB0aW1lGAIg",
-            "ASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uUgZ1cHRpbWUSJQoOcmVx",
-            "dWVzdHNfdG90YWwYAyABKARSDXJlcXVlc3RzVG90YWwi/gIKBUV2ZW50EksK",
-            "DGFwaV9hY3Rpdml0eRgBIAEoCzImLmNlcmJvcy50ZWxlbWV0cnkudjEuRXZl",
-            "bnQuQXBpQWN0aXZpdHlIAFILYXBpQWN0aXZpdHkaMwoJQ291bnRTdGF0EhAK",
-            "A2tleRgBIAEoCVIDa2V5EhQKBWNvdW50GAIgASgEUgVjb3VudBrqAQoLQXBp",
-            "QWN0aXZpdHkSGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbhIxCgZ1cHRpbWUY",
-            "AiABKAsyGS5nb29nbGUucHJvdG9idWYuRHVyYXRpb25SBnVwdGltZRJHCgxt",
-            "ZXRob2RfY2FsbHMYAyADKAsyJC5jZXJib3MudGVsZW1ldHJ5LnYxLkV2ZW50",
-            "LkNvdW50U3RhdFILbWV0aG9kQ2FsbHMSRQoLdXNlcl9hZ2VudHMYBCADKAsy",
-            "JC5jZXJib3MudGVsZW1ldHJ5LnYxLkV2ZW50LkNvdW50U3RhdFIKdXNlckFn",
-            "ZW50c0IGCgRkYXRhQnsKG2Rldi5jZXJib3MuYXBpLnYxLnRlbGVtZXRyeVpC",
-            "Z2l0aHViLmNvbS9jZXJib3MvY2VyYm9zL2FwaS9nZW5wYi9jZXJib3MvdGVs",
-            "ZW1ldHJ5L3YxO3RlbGVtZXRyeXYxqgIXQ2VyYm9zLkFwaS5WMS5UZWxlbWV0",
-            "cnliBnByb3RvMw=="));
+            "RmVhdHVyZXMuU3RvcmFnZS5CbG9iSABSBGJsb2ISUwoGYnVuZGxlGAUgASgL",
+            "MjkuY2VyYm9zLnRlbGVtZXRyeS52MS5TZXJ2ZXJMYXVuY2guRmVhdHVyZXMu",
+            "U3RvcmFnZS5CdW5kbGVIAFIGYnVuZGxlGhwKBERpc2sSFAoFd2F0Y2gYASAB",
+            "KAhSBXdhdGNoGnUKA0dpdBIaCghwcm90b2NvbBgBIAEoCVIIcHJvdG9jb2wS",
+            "EgoEYXV0aBgCIAEoCFIEYXV0aBI+Cg1wb2xsX2ludGVydmFsGAMgASgLMhku",
+            "Z29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uUgxwb2xsSW50ZXJ2YWwaYgoEQmxv",
+            "YhIaCghwcm92aWRlchgBIAEoCVIIcHJvdmlkZXISPgoNcG9sbF9pbnRlcnZh",
+            "bBgCIAEoCzIZLmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvblIMcG9sbEludGVy",
+            "dmFsGmEKBkJ1bmRsZRIVCgZwZHBfaWQYASABKAlSBXBkcElkEiMKDWJ1bmRs",
+            "ZV9zb3VyY2UYAiABKAlSDGJ1bmRsZVNvdXJjZRIbCgljbGllbnRfaWQYAyAB",
+            "KAlSCGNsaWVudElkQgcKBXN0b3JlGrMFCgVTdGF0cxJGCgZwb2xpY3kYASAB",
+            "KAsyLi5jZXJib3MudGVsZW1ldHJ5LnYxLlNlcnZlckxhdW5jaC5TdGF0cy5Q",
+            "b2xpY3lSBnBvbGljeRJGCgZzY2hlbWEYAiABKAsyLi5jZXJib3MudGVsZW1l",
+            "dHJ5LnYxLlNlcnZlckxhdW5jaC5TdGF0cy5TY2hlbWFSBnNjaGVtYRr5AwoG",
+            "UG9saWN5Ek8KBWNvdW50GAEgAygLMjkuY2VyYm9zLnRlbGVtZXRyeS52MS5T",
+            "ZXJ2ZXJMYXVuY2guU3RhdHMuUG9saWN5LkNvdW50RW50cnlSBWNvdW50EmYK",
+            "DmF2Z19ydWxlX2NvdW50GAIgAygLMkAuY2VyYm9zLnRlbGVtZXRyeS52MS5T",
+            "ZXJ2ZXJMYXVuY2guU3RhdHMuUG9saWN5LkF2Z1J1bGVDb3VudEVudHJ5Ugxh",
+            "dmdSdWxlQ291bnQSdQoTYXZnX2NvbmRpdGlvbl9jb3VudBgDIAMoCzJFLmNl",
+            "cmJvcy50ZWxlbWV0cnkudjEuU2VydmVyTGF1bmNoLlN0YXRzLlBvbGljeS5B",
+            "dmdDb25kaXRpb25Db3VudEVudHJ5UhFhdmdDb25kaXRpb25Db3VudBo4CgpD",
+            "b3VudEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgNUgV2",
+            "YWx1ZToCOAEaPwoRQXZnUnVsZUNvdW50RW50cnkSEAoDa2V5GAEgASgJUgNr",
+            "ZXkSFAoFdmFsdWUYAiABKAFSBXZhbHVlOgI4ARpEChZBdmdDb25kaXRpb25D",
+            "b3VudEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgBUgV2",
+            "YWx1ZToCOAEaHgoGU2NoZW1hEhQKBWNvdW50GAEgASgNUgVjb3VudCKAAQoK",
+            "U2VydmVyU3RvcBIYCgd2ZXJzaW9uGAEgASgJUgd2ZXJzaW9uEjEKBnVwdGlt",
+            "ZRgCIAEoCzIZLmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvblIGdXB0aW1lEiUK",
+            "DnJlcXVlc3RzX3RvdGFsGAMgASgEUg1yZXF1ZXN0c1RvdGFsIv4CCgVFdmVu",
+            "dBJLCgxhcGlfYWN0aXZpdHkYASABKAsyJi5jZXJib3MudGVsZW1ldHJ5LnYx",
+            "LkV2ZW50LkFwaUFjdGl2aXR5SABSC2FwaUFjdGl2aXR5GjMKCUNvdW50U3Rh",
+            "dBIQCgNrZXkYASABKAlSA2tleRIUCgVjb3VudBgCIAEoBFIFY291bnQa6gEK",
+            "C0FwaUFjdGl2aXR5EhgKB3ZlcnNpb24YASABKAlSB3ZlcnNpb24SMQoGdXB0",
+            "aW1lGAIgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uUgZ1cHRpbWUS",
+            "RwoMbWV0aG9kX2NhbGxzGAMgAygLMiQuY2VyYm9zLnRlbGVtZXRyeS52MS5F",
+            "dmVudC5Db3VudFN0YXRSC21ldGhvZENhbGxzEkUKC3VzZXJfYWdlbnRzGAQg",
+            "AygLMiQuY2VyYm9zLnRlbGVtZXRyeS52MS5FdmVudC5Db3VudFN0YXRSCnVz",
+            "ZXJBZ2VudHNCBgoEZGF0YUJ7ChtkZXYuY2VyYm9zLmFwaS52MS50ZWxlbWV0",
+            "cnlaQmdpdGh1Yi5jb20vY2VyYm9zL2NlcmJvcy9hcGkvZ2VucGIvY2VyYm9z",
+            "L3RlbGVtZXRyeS92MTt0ZWxlbWV0cnl2MaoCF0NlcmJvcy5BcGkuVjEuVGVs",
+            "ZW1ldHJ5YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -99,9 +103,10 @@ namespace Cerbos.Api.V1.Telemetry {
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Parser, new[]{ "Audit", "Schema", "AdminApi", "Storage" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Audit), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Audit.Parser, new[]{ "Enabled", "Backend" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Schema), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Schema.Parser, new[]{ "Enforcement" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.AdminApi), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.AdminApi.Parser, new[]{ "Enabled" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Parser, new[]{ "Driver", "Disk", "Git", "Blob" }, new[]{ "Store" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Disk), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Disk.Parser, new[]{ "Watch" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Parser, new[]{ "Driver", "Disk", "Git", "Blob", "Bundle" }, new[]{ "Store" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Disk), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Disk.Parser, new[]{ "Watch" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Git), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Git.Parser, new[]{ "Protocol", "Auth", "PollInterval" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Blob), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Blob.Parser, new[]{ "Provider", "PollInterval" }, null, null, null, null)})}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Blob), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Blob.Parser, new[]{ "Provider", "PollInterval" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle.Parser, new[]{ "PdpId", "BundleSource", "ClientId" }, null, null, null, null)})}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Stats), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Stats.Parser, new[]{ "Policy", "Schema" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Stats.Types.Policy), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Stats.Types.Policy.Parser, new[]{ "Count", "AvgRuleCount", "AvgConditionCount" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Stats.Types.Schema), global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Stats.Types.Schema.Parser, new[]{ "Count" }, null, null, null, null)})}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Cerbos.Api.V1.Telemetry.ServerStop), global::Cerbos.Api.V1.Telemetry.ServerStop.Parser, new[]{ "Version", "Uptime", "RequestsTotal" }, null, null, null, null),
@@ -2077,6 +2082,9 @@ namespace Cerbos.Api.V1.Telemetry {
                 case StoreOneofCase.Blob:
                   Blob = other.Blob.Clone();
                   break;
+                case StoreOneofCase.Bundle:
+                  Bundle = other.Bundle.Clone();
+                  break;
               }
 
               _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -2136,6 +2144,18 @@ namespace Cerbos.Api.V1.Telemetry {
               }
             }
 
+            /// <summary>Field number for the "bundle" field.</summary>
+            public const int BundleFieldNumber = 5;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle Bundle {
+              get { return storeCase_ == StoreOneofCase.Bundle ? (global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle) store_ : null; }
+              set {
+                store_ = value;
+                storeCase_ = value == null ? StoreOneofCase.None : StoreOneofCase.Bundle;
+              }
+            }
+
             private object store_;
             /// <summary>Enum of possible cases for the "store" oneof.</summary>
             public enum StoreOneofCase {
@@ -2143,6 +2163,7 @@ namespace Cerbos.Api.V1.Telemetry {
               Disk = 2,
               Git = 3,
               Blob = 4,
+              Bundle = 5,
             }
             private StoreOneofCase storeCase_ = StoreOneofCase.None;
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2177,6 +2198,7 @@ namespace Cerbos.Api.V1.Telemetry {
               if (!object.Equals(Disk, other.Disk)) return false;
               if (!object.Equals(Git, other.Git)) return false;
               if (!object.Equals(Blob, other.Blob)) return false;
+              if (!object.Equals(Bundle, other.Bundle)) return false;
               if (StoreCase != other.StoreCase) return false;
               return Equals(_unknownFields, other._unknownFields);
             }
@@ -2189,6 +2211,7 @@ namespace Cerbos.Api.V1.Telemetry {
               if (storeCase_ == StoreOneofCase.Disk) hash ^= Disk.GetHashCode();
               if (storeCase_ == StoreOneofCase.Git) hash ^= Git.GetHashCode();
               if (storeCase_ == StoreOneofCase.Blob) hash ^= Blob.GetHashCode();
+              if (storeCase_ == StoreOneofCase.Bundle) hash ^= Bundle.GetHashCode();
               hash ^= (int) storeCase_;
               if (_unknownFields != null) {
                 hash ^= _unknownFields.GetHashCode();
@@ -2224,6 +2247,10 @@ namespace Cerbos.Api.V1.Telemetry {
                 output.WriteRawTag(34);
                 output.WriteMessage(Blob);
               }
+              if (storeCase_ == StoreOneofCase.Bundle) {
+                output.WriteRawTag(42);
+                output.WriteMessage(Bundle);
+              }
               if (_unknownFields != null) {
                 _unknownFields.WriteTo(output);
               }
@@ -2250,6 +2277,10 @@ namespace Cerbos.Api.V1.Telemetry {
                 output.WriteRawTag(34);
                 output.WriteMessage(Blob);
               }
+              if (storeCase_ == StoreOneofCase.Bundle) {
+                output.WriteRawTag(42);
+                output.WriteMessage(Bundle);
+              }
               if (_unknownFields != null) {
                 _unknownFields.WriteTo(ref output);
               }
@@ -2271,6 +2302,9 @@ namespace Cerbos.Api.V1.Telemetry {
               }
               if (storeCase_ == StoreOneofCase.Blob) {
                 size += 1 + pb::CodedOutputStream.ComputeMessageSize(Blob);
+              }
+              if (storeCase_ == StoreOneofCase.Bundle) {
+                size += 1 + pb::CodedOutputStream.ComputeMessageSize(Bundle);
               }
               if (_unknownFields != null) {
                 size += _unknownFields.CalculateSize();
@@ -2305,6 +2339,12 @@ namespace Cerbos.Api.V1.Telemetry {
                     Blob = new global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Blob();
                   }
                   Blob.MergeFrom(other.Blob);
+                  break;
+                case StoreOneofCase.Bundle:
+                  if (Bundle == null) {
+                    Bundle = new global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle();
+                  }
+                  Bundle.MergeFrom(other.Bundle);
                   break;
               }
 
@@ -2354,6 +2394,15 @@ namespace Cerbos.Api.V1.Telemetry {
                     Blob = subBuilder;
                     break;
                   }
+                  case 42: {
+                    global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle subBuilder = new global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle();
+                    if (storeCase_ == StoreOneofCase.Bundle) {
+                      subBuilder.MergeFrom(Bundle);
+                    }
+                    input.ReadMessage(subBuilder);
+                    Bundle = subBuilder;
+                    break;
+                  }
                 }
               }
             #endif
@@ -2398,6 +2447,15 @@ namespace Cerbos.Api.V1.Telemetry {
                     }
                     input.ReadMessage(subBuilder);
                     Blob = subBuilder;
+                    break;
+                  }
+                  case 42: {
+                    global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle subBuilder = new global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Types.Bundle();
+                    if (storeCase_ == StoreOneofCase.Bundle) {
+                      subBuilder.MergeFrom(Bundle);
+                    }
+                    input.ReadMessage(subBuilder);
+                    Bundle = subBuilder;
                     break;
                   }
                 }
@@ -3106,6 +3164,269 @@ namespace Cerbos.Api.V1.Telemetry {
 
               }
 
+              public sealed partial class Bundle : pb::IMessage<Bundle>
+              #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+                  , pb::IBufferMessage
+              #endif
+              {
+                private static readonly pb::MessageParser<Bundle> _parser = new pb::MessageParser<Bundle>(() => new Bundle());
+                private pb::UnknownFieldSet _unknownFields;
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public static pb::MessageParser<Bundle> Parser { get { return _parser; } }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public static pbr::MessageDescriptor Descriptor {
+                  get { return global::Cerbos.Api.V1.Telemetry.ServerLaunch.Types.Features.Types.Storage.Descriptor.NestedTypes[3]; }
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                pbr::MessageDescriptor pb::IMessage.Descriptor {
+                  get { return Descriptor; }
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public Bundle() {
+                  OnConstruction();
+                }
+
+                partial void OnConstruction();
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public Bundle(Bundle other) : this() {
+                  pdpId_ = other.pdpId_;
+                  bundleSource_ = other.bundleSource_;
+                  clientId_ = other.clientId_;
+                  _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public Bundle Clone() {
+                  return new Bundle(this);
+                }
+
+                /// <summary>Field number for the "pdp_id" field.</summary>
+                public const int PdpIdFieldNumber = 1;
+                private string pdpId_ = "";
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public string PdpId {
+                  get { return pdpId_; }
+                  set {
+                    pdpId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+                  }
+                }
+
+                /// <summary>Field number for the "bundle_source" field.</summary>
+                public const int BundleSourceFieldNumber = 2;
+                private string bundleSource_ = "";
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public string BundleSource {
+                  get { return bundleSource_; }
+                  set {
+                    bundleSource_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+                  }
+                }
+
+                /// <summary>Field number for the "client_id" field.</summary>
+                public const int ClientIdFieldNumber = 3;
+                private string clientId_ = "";
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public string ClientId {
+                  get { return clientId_; }
+                  set {
+                    clientId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+                  }
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public override bool Equals(object other) {
+                  return Equals(other as Bundle);
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public bool Equals(Bundle other) {
+                  if (ReferenceEquals(other, null)) {
+                    return false;
+                  }
+                  if (ReferenceEquals(other, this)) {
+                    return true;
+                  }
+                  if (PdpId != other.PdpId) return false;
+                  if (BundleSource != other.BundleSource) return false;
+                  if (ClientId != other.ClientId) return false;
+                  return Equals(_unknownFields, other._unknownFields);
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public override int GetHashCode() {
+                  int hash = 1;
+                  if (PdpId.Length != 0) hash ^= PdpId.GetHashCode();
+                  if (BundleSource.Length != 0) hash ^= BundleSource.GetHashCode();
+                  if (ClientId.Length != 0) hash ^= ClientId.GetHashCode();
+                  if (_unknownFields != null) {
+                    hash ^= _unknownFields.GetHashCode();
+                  }
+                  return hash;
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public override string ToString() {
+                  return pb::JsonFormatter.ToDiagnosticString(this);
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public void WriteTo(pb::CodedOutputStream output) {
+                #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+                  output.WriteRawMessage(this);
+                #else
+                  if (PdpId.Length != 0) {
+                    output.WriteRawTag(10);
+                    output.WriteString(PdpId);
+                  }
+                  if (BundleSource.Length != 0) {
+                    output.WriteRawTag(18);
+                    output.WriteString(BundleSource);
+                  }
+                  if (ClientId.Length != 0) {
+                    output.WriteRawTag(26);
+                    output.WriteString(ClientId);
+                  }
+                  if (_unknownFields != null) {
+                    _unknownFields.WriteTo(output);
+                  }
+                #endif
+                }
+
+                #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+                  if (PdpId.Length != 0) {
+                    output.WriteRawTag(10);
+                    output.WriteString(PdpId);
+                  }
+                  if (BundleSource.Length != 0) {
+                    output.WriteRawTag(18);
+                    output.WriteString(BundleSource);
+                  }
+                  if (ClientId.Length != 0) {
+                    output.WriteRawTag(26);
+                    output.WriteString(ClientId);
+                  }
+                  if (_unknownFields != null) {
+                    _unknownFields.WriteTo(ref output);
+                  }
+                }
+                #endif
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public int CalculateSize() {
+                  int size = 0;
+                  if (PdpId.Length != 0) {
+                    size += 1 + pb::CodedOutputStream.ComputeStringSize(PdpId);
+                  }
+                  if (BundleSource.Length != 0) {
+                    size += 1 + pb::CodedOutputStream.ComputeStringSize(BundleSource);
+                  }
+                  if (ClientId.Length != 0) {
+                    size += 1 + pb::CodedOutputStream.ComputeStringSize(ClientId);
+                  }
+                  if (_unknownFields != null) {
+                    size += _unknownFields.CalculateSize();
+                  }
+                  return size;
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public void MergeFrom(Bundle other) {
+                  if (other == null) {
+                    return;
+                  }
+                  if (other.PdpId.Length != 0) {
+                    PdpId = other.PdpId;
+                  }
+                  if (other.BundleSource.Length != 0) {
+                    BundleSource = other.BundleSource;
+                  }
+                  if (other.ClientId.Length != 0) {
+                    ClientId = other.ClientId;
+                  }
+                  _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                public void MergeFrom(pb::CodedInputStream input) {
+                #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+                  input.ReadRawMessage(this);
+                #else
+                  uint tag;
+                  while ((tag = input.ReadTag()) != 0) {
+                    switch(tag) {
+                      default:
+                        _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                        break;
+                      case 10: {
+                        PdpId = input.ReadString();
+                        break;
+                      }
+                      case 18: {
+                        BundleSource = input.ReadString();
+                        break;
+                      }
+                      case 26: {
+                        ClientId = input.ReadString();
+                        break;
+                      }
+                    }
+                  }
+                #endif
+                }
+
+                #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+                [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+                [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+                void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+                  uint tag;
+                  while ((tag = input.ReadTag()) != 0) {
+                    switch(tag) {
+                      default:
+                        _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                        break;
+                      case 10: {
+                        PdpId = input.ReadString();
+                        break;
+                      }
+                      case 18: {
+                        BundleSource = input.ReadString();
+                        break;
+                      }
+                      case 26: {
+                        ClientId = input.ReadString();
+                        break;
+                      }
+                    }
+                  }
+                }
+                #endif
+
+              }
+
             }
             #endregion
 
@@ -3529,9 +3850,9 @@ namespace Cerbos.Api.V1.Telemetry {
               if (other == null) {
                 return;
               }
-              count_.Add(other.count_);
-              avgRuleCount_.Add(other.avgRuleCount_);
-              avgConditionCount_.Add(other.avgConditionCount_);
+              count_.MergeFrom(other.count_);
+              avgRuleCount_.MergeFrom(other.avgRuleCount_);
+              avgConditionCount_.MergeFrom(other.avgConditionCount_);
               _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
             }
 

--- a/src/Sdk/Cerbos/Sdk/CerbosBlockingClient.cs
+++ b/src/Sdk/Cerbos/Sdk/CerbosBlockingClient.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.ComponentModel.Design.Serialization;
 using Cerbos.Api.V1.Request;
 using Cerbos.Api.V1.Response;
 using Cerbos.Api.V1.Svc;
@@ -16,6 +17,7 @@ namespace Cerbos.Sdk
     {
         private readonly CerbosService.CerbosServiceClient _csc;
         private readonly Builders.AuxData _auxData;
+        private bool _includeMeta = false;
 
         public CerbosBlockingClient(CerbosService.CerbosServiceClient csc)
         {
@@ -35,6 +37,15 @@ namespace Cerbos.Sdk
         {
             return new CerbosBlockingClient(_csc, auxData);
         }
+        
+        /// <summary>
+        /// Set includeMeta field for the requests
+        /// </summary>
+        public CerbosBlockingClient WithMeta(bool include)
+        {
+            _includeMeta = include;
+            return this;
+        }
 
         /// <summary>
         /// Send a request consisting of a principal, resource(s) & action(s) to see if the principal is authorized to do the action(s) on the resource(s).
@@ -45,6 +56,7 @@ namespace Cerbos.Sdk
             try
             {
                 request.AuxData = _auxData?.ToAuxData();
+                request.IncludeMeta = _includeMeta;
                 response = _csc.CheckResources(request);
             }
             catch (Exception e)
@@ -65,7 +77,7 @@ namespace Cerbos.Sdk
             var request = new CheckResourcesRequest
             {
                 RequestId = requestId,
-                IncludeMeta = false,
+                IncludeMeta = _includeMeta,
                 Principal = principal.ToPrincipal(),
             };
 
@@ -96,7 +108,7 @@ namespace Cerbos.Sdk
             var result = CheckResources(new CheckResourcesRequest
             {
                 RequestId = requestId,
-                IncludeMeta = false,
+                IncludeMeta = _includeMeta,
                 Principal = principal.ToPrincipal(),
                 Resources = { resourceAction.ToResourceEntry() }
             });
@@ -139,6 +151,7 @@ namespace Cerbos.Sdk
             try
             {
                 request.AuxData = _auxData?.ToAuxData();
+                request.IncludeMeta = _includeMeta;
                 response = _csc.PlanResources(request);
             }
             catch (Exception e)
@@ -155,7 +168,7 @@ namespace Cerbos.Sdk
             {
                 RequestId = requestId,
                 Action = action,
-                IncludeMeta = false,
+                IncludeMeta = _includeMeta,
                 Principal = principal.ToPrincipal(),
                 Resource = resource.ToPlanResource(),
             };

--- a/src/Sdk/Cerbos/Sdk/CheckResourcesResult.cs
+++ b/src/Sdk/Cerbos/Sdk/CheckResourcesResult.cs
@@ -16,9 +16,11 @@ namespace Cerbos.Sdk
     public class CheckResourcesResult
     {
         private readonly CheckResourcesResponse _response;
+        public string RequestId { get; }
 
         public CheckResourcesResult(CheckResourcesResponse resp) {
             _response = resp;
+            RequestId = _response.RequestId;
         }
         
         public List<CheckResult> Results()
@@ -26,7 +28,7 @@ namespace Cerbos.Sdk
             List<CheckResult> results = new List<CheckResult>();
             foreach (var result in _response.Results)
             {
-                results.Add(new CheckResult(result.Actions));
+                results.Add(new CheckResult(result));
             }
 
             return results;
@@ -44,7 +46,7 @@ namespace Cerbos.Sdk
             {
                 if (result.Resource.Id.Equals(resourceId))
                 {
-                    return new CheckResult(result.Actions);
+                    return new CheckResult(result);
                 }
             }
 

--- a/src/Sdk/Cerbos/Sdk/CheckResult.cs
+++ b/src/Sdk/Cerbos/Sdk/CheckResult.cs
@@ -116,7 +116,7 @@ namespace Cerbos.Sdk
 
                 public Value Get(string src)
                 {
-                    return _outputs.Find(outputEntry => outputEntry.Src == src).Val;
+                    return _outputs.Find(outputEntry => outputEntry.Src == src)?.Val;
                 }
 
                 public Dictionary<string, Value> ToDictionary()

--- a/src/Sdk/Cerbos/Sdk/CheckResult.cs
+++ b/src/Sdk/Cerbos/Sdk/CheckResult.cs
@@ -116,7 +116,7 @@ namespace Cerbos.Sdk
 
                 public Value Get(string src)
                 {
-                    return ToDictionary()[src];
+                    return _outputs.Find(outputEntry => outputEntry.Src == src).Val;
                 }
 
                 public Dictionary<string, Value> ToDictionary()

--- a/src/Sdk/Cerbos/Sdk/CheckResult.cs
+++ b/src/Sdk/Cerbos/Sdk/CheckResult.cs
@@ -3,7 +3,8 @@
 
 using System.Collections.Generic;
 using Cerbos.Api.V1.Effect;
-using Google.Protobuf.Collections;
+using Cerbos.Api.V1.Engine;
+using Cerbos.Api.V1.Response;
 
 namespace Cerbos.Sdk
 {
@@ -17,15 +18,28 @@ namespace Cerbos.Sdk
     public class CheckResult
     {
         private readonly Dictionary<string, Effect> _effects;
+        public CheckResourcesResponse.Types.ResultEntry.Types.Resource Resource { get; }
+        public CheckResourcesResponse.Types.ResultEntry.Types.Meta Meta { get; }
+        public List<OutputEntry> Outputs { get; }
 
-        public CheckResult(MapField<string, Effect> effects)
+        public CheckResult(CheckResourcesResponse.Types.ResultEntry result)
         {
             var effectsDictionary = new Dictionary<string, Effect>();
-            foreach (var effect in effects)
+            foreach (var kvp in result.Actions)
             {
-                effectsDictionary.Add(effect.Key, effect.Value);
+                effectsDictionary.Add(kvp.Key, kvp.Value);
             }
             _effects = effectsDictionary;
+
+            Meta = result.Meta;
+            Resource = result.Resource;
+            
+            var outputList = new List<OutputEntry>();
+            foreach (var output in result.Outputs)
+            {
+                outputList.Add(output);
+            }
+            Outputs = outputList;
         }
 
         public CheckResult(Dictionary<string, Effect> effects) {

--- a/src/Sdk/Google/Api/Expr/V1Alpha1/Checked.g.cs
+++ b/src/Sdk/Google/Api/Expr/V1Alpha1/Checked.g.cs
@@ -382,8 +382,8 @@ namespace Google.Api.Expr.V1Alpha1 {
       if (other == null) {
         return;
       }
-      referenceMap_.Add(other.referenceMap_);
-      typeMap_.Add(other.typeMap_);
+      referenceMap_.MergeFrom(other.referenceMap_);
+      typeMap_.MergeFrom(other.typeMap_);
       if (other.sourceInfo_ != null) {
         if (sourceInfo_ == null) {
           SourceInfo = new global::Google.Api.Expr.V1Alpha1.SourceInfo();
@@ -599,10 +599,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Google.Protobuf.WellKnownTypes.NullValue Null {
-      get { return typeKindCase_ == TypeKindOneofCase.Null ? (global::Google.Protobuf.WellKnownTypes.NullValue) typeKind_ : global::Google.Protobuf.WellKnownTypes.NullValue.NullValue; }
+      get { return HasNull ? (global::Google.Protobuf.WellKnownTypes.NullValue) typeKind_ : global::Google.Protobuf.WellKnownTypes.NullValue.NullValue; }
       set {
         typeKind_ = value;
         typeKindCase_ = TypeKindOneofCase.Null;
+      }
+    }
+    /// <summary>Gets whether the "null" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasNull {
+      get { return typeKindCase_ == TypeKindOneofCase.Null; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "null" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearNull() {
+      if (HasNull) {
+        ClearTypeKind();
       }
     }
 
@@ -614,10 +628,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType Primitive {
-      get { return typeKindCase_ == TypeKindOneofCase.Primitive ? (global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType) typeKind_ : global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType.Unspecified; }
+      get { return HasPrimitive ? (global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType) typeKind_ : global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType.Unspecified; }
       set {
         typeKind_ = value;
         typeKindCase_ = TypeKindOneofCase.Primitive;
+      }
+    }
+    /// <summary>Gets whether the "primitive" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPrimitive {
+      get { return typeKindCase_ == TypeKindOneofCase.Primitive; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "primitive" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPrimitive() {
+      if (HasPrimitive) {
+        ClearTypeKind();
       }
     }
 
@@ -629,10 +657,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType Wrapper {
-      get { return typeKindCase_ == TypeKindOneofCase.Wrapper ? (global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType) typeKind_ : global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType.Unspecified; }
+      get { return HasWrapper ? (global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType) typeKind_ : global::Google.Api.Expr.V1Alpha1.Type.Types.PrimitiveType.Unspecified; }
       set {
         typeKind_ = value;
         typeKindCase_ = TypeKindOneofCase.Wrapper;
+      }
+    }
+    /// <summary>Gets whether the "wrapper" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasWrapper {
+      get { return typeKindCase_ == TypeKindOneofCase.Wrapper; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "wrapper" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearWrapper() {
+      if (HasWrapper) {
+        ClearTypeKind();
       }
     }
 
@@ -644,10 +686,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Google.Api.Expr.V1Alpha1.Type.Types.WellKnownType WellKnown {
-      get { return typeKindCase_ == TypeKindOneofCase.WellKnown ? (global::Google.Api.Expr.V1Alpha1.Type.Types.WellKnownType) typeKind_ : global::Google.Api.Expr.V1Alpha1.Type.Types.WellKnownType.Unspecified; }
+      get { return HasWellKnown ? (global::Google.Api.Expr.V1Alpha1.Type.Types.WellKnownType) typeKind_ : global::Google.Api.Expr.V1Alpha1.Type.Types.WellKnownType.Unspecified; }
       set {
         typeKind_ = value;
         typeKindCase_ = TypeKindOneofCase.WellKnown;
+      }
+    }
+    /// <summary>Gets whether the "well_known" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasWellKnown {
+      get { return typeKindCase_ == TypeKindOneofCase.WellKnown; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "well_known" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearWellKnown() {
+      if (HasWellKnown) {
+        ClearTypeKind();
       }
     }
 
@@ -707,10 +763,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string MessageType {
-      get { return typeKindCase_ == TypeKindOneofCase.MessageType ? (string) typeKind_ : ""; }
+      get { return HasMessageType ? (string) typeKind_ : ""; }
       set {
         typeKind_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         typeKindCase_ = TypeKindOneofCase.MessageType;
+      }
+    }
+    /// <summary>Gets whether the "message_type" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasMessageType {
+      get { return typeKindCase_ == TypeKindOneofCase.MessageType; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "message_type" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearMessageType() {
+      if (HasMessageType) {
+        ClearTypeKind();
       }
     }
 
@@ -726,10 +796,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string TypeParam {
-      get { return typeKindCase_ == TypeKindOneofCase.TypeParam ? (string) typeKind_ : ""; }
+      get { return HasTypeParam ? (string) typeKind_ : ""; }
       set {
         typeKind_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         typeKindCase_ = TypeKindOneofCase.TypeParam;
+      }
+    }
+    /// <summary>Gets whether the "type_param" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasTypeParam {
+      get { return typeKindCase_ == TypeKindOneofCase.TypeParam; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "type_param" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearTypeParam() {
+      if (HasTypeParam) {
+        ClearTypeKind();
       }
     }
 
@@ -854,15 +938,15 @@ namespace Google.Api.Expr.V1Alpha1 {
     public override int GetHashCode() {
       int hash = 1;
       if (typeKindCase_ == TypeKindOneofCase.Dyn) hash ^= Dyn.GetHashCode();
-      if (typeKindCase_ == TypeKindOneofCase.Null) hash ^= Null.GetHashCode();
-      if (typeKindCase_ == TypeKindOneofCase.Primitive) hash ^= Primitive.GetHashCode();
-      if (typeKindCase_ == TypeKindOneofCase.Wrapper) hash ^= Wrapper.GetHashCode();
-      if (typeKindCase_ == TypeKindOneofCase.WellKnown) hash ^= WellKnown.GetHashCode();
+      if (HasNull) hash ^= Null.GetHashCode();
+      if (HasPrimitive) hash ^= Primitive.GetHashCode();
+      if (HasWrapper) hash ^= Wrapper.GetHashCode();
+      if (HasWellKnown) hash ^= WellKnown.GetHashCode();
       if (typeKindCase_ == TypeKindOneofCase.ListType) hash ^= ListType.GetHashCode();
       if (typeKindCase_ == TypeKindOneofCase.MapType) hash ^= MapType.GetHashCode();
       if (typeKindCase_ == TypeKindOneofCase.Function) hash ^= Function.GetHashCode();
-      if (typeKindCase_ == TypeKindOneofCase.MessageType) hash ^= MessageType.GetHashCode();
-      if (typeKindCase_ == TypeKindOneofCase.TypeParam) hash ^= TypeParam.GetHashCode();
+      if (HasMessageType) hash ^= MessageType.GetHashCode();
+      if (HasTypeParam) hash ^= TypeParam.GetHashCode();
       if (typeKindCase_ == TypeKindOneofCase.Type_) hash ^= Type_.GetHashCode();
       if (typeKindCase_ == TypeKindOneofCase.Error) hash ^= Error.GetHashCode();
       if (typeKindCase_ == TypeKindOneofCase.AbstractType) hash ^= AbstractType.GetHashCode();
@@ -889,19 +973,19 @@ namespace Google.Api.Expr.V1Alpha1 {
         output.WriteRawTag(10);
         output.WriteMessage(Dyn);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Null) {
+      if (HasNull) {
         output.WriteRawTag(16);
         output.WriteEnum((int) Null);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Primitive) {
+      if (HasPrimitive) {
         output.WriteRawTag(24);
         output.WriteEnum((int) Primitive);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Wrapper) {
+      if (HasWrapper) {
         output.WriteRawTag(32);
         output.WriteEnum((int) Wrapper);
       }
-      if (typeKindCase_ == TypeKindOneofCase.WellKnown) {
+      if (HasWellKnown) {
         output.WriteRawTag(40);
         output.WriteEnum((int) WellKnown);
       }
@@ -917,11 +1001,11 @@ namespace Google.Api.Expr.V1Alpha1 {
         output.WriteRawTag(66);
         output.WriteMessage(Function);
       }
-      if (typeKindCase_ == TypeKindOneofCase.MessageType) {
+      if (HasMessageType) {
         output.WriteRawTag(74);
         output.WriteString(MessageType);
       }
-      if (typeKindCase_ == TypeKindOneofCase.TypeParam) {
+      if (HasTypeParam) {
         output.WriteRawTag(82);
         output.WriteString(TypeParam);
       }
@@ -951,19 +1035,19 @@ namespace Google.Api.Expr.V1Alpha1 {
         output.WriteRawTag(10);
         output.WriteMessage(Dyn);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Null) {
+      if (HasNull) {
         output.WriteRawTag(16);
         output.WriteEnum((int) Null);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Primitive) {
+      if (HasPrimitive) {
         output.WriteRawTag(24);
         output.WriteEnum((int) Primitive);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Wrapper) {
+      if (HasWrapper) {
         output.WriteRawTag(32);
         output.WriteEnum((int) Wrapper);
       }
-      if (typeKindCase_ == TypeKindOneofCase.WellKnown) {
+      if (HasWellKnown) {
         output.WriteRawTag(40);
         output.WriteEnum((int) WellKnown);
       }
@@ -979,11 +1063,11 @@ namespace Google.Api.Expr.V1Alpha1 {
         output.WriteRawTag(66);
         output.WriteMessage(Function);
       }
-      if (typeKindCase_ == TypeKindOneofCase.MessageType) {
+      if (HasMessageType) {
         output.WriteRawTag(74);
         output.WriteString(MessageType);
       }
-      if (typeKindCase_ == TypeKindOneofCase.TypeParam) {
+      if (HasTypeParam) {
         output.WriteRawTag(82);
         output.WriteString(TypeParam);
       }
@@ -1012,16 +1096,16 @@ namespace Google.Api.Expr.V1Alpha1 {
       if (typeKindCase_ == TypeKindOneofCase.Dyn) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Dyn);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Null) {
+      if (HasNull) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Null);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Primitive) {
+      if (HasPrimitive) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Primitive);
       }
-      if (typeKindCase_ == TypeKindOneofCase.Wrapper) {
+      if (HasWrapper) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Wrapper);
       }
-      if (typeKindCase_ == TypeKindOneofCase.WellKnown) {
+      if (HasWellKnown) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) WellKnown);
       }
       if (typeKindCase_ == TypeKindOneofCase.ListType) {
@@ -1033,10 +1117,10 @@ namespace Google.Api.Expr.V1Alpha1 {
       if (typeKindCase_ == TypeKindOneofCase.Function) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Function);
       }
-      if (typeKindCase_ == TypeKindOneofCase.MessageType) {
+      if (HasMessageType) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(MessageType);
       }
-      if (typeKindCase_ == TypeKindOneofCase.TypeParam) {
+      if (HasTypeParam) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TypeParam);
       }
       if (typeKindCase_ == TypeKindOneofCase.Type_) {
@@ -2398,9 +2482,11 @@ namespace Google.Api.Expr.V1Alpha1 {
     /// Declarations are organized in containers and this represents the full path
     /// to the declaration in its container, as in `google.api.expr.Decl`.
     ///
-    /// Declarations used as [FunctionDecl.Overload][google.api.expr.v1alpha1.Decl.FunctionDecl.Overload] parameters may or may not
-    /// have a name depending on whether the overload is function declaration or a
-    /// function definition containing a result [Expr][google.api.expr.v1alpha1.Expr].
+    /// Declarations used as
+    /// [FunctionDecl.Overload][google.api.expr.v1alpha1.Decl.FunctionDecl.Overload]
+    /// parameters may or may not have a name depending on whether the overload is
+    /// function declaration or a function definition containing a result
+    /// [Expr][google.api.expr.v1alpha1.Expr].
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -3169,8 +3255,8 @@ namespace Google.Api.Expr.V1Alpha1 {
         public static partial class Types {
           /// <summary>
           /// An overload indicates a function's parameter types and return type, and
-          /// may optionally include a function body described in terms of [Expr][google.api.expr.v1alpha1.Expr]
-          /// values.
+          /// may optionally include a function body described in terms of
+          /// [Expr][google.api.expr.v1alpha1.Expr] values.
           ///
           /// Functions overloads are declared in either a function or method
           /// call-style. For methods, the `params[0]` is the expected type of the
@@ -3235,8 +3321,9 @@ namespace Google.Api.Expr.V1Alpha1 {
             /// Required. Globally unique overload name of the function which reflects
             /// the function name and argument types.
             ///
-            /// This will be used by a [Reference][google.api.expr.v1alpha1.Reference] to indicate the `overload_id` that
-            /// was resolved for the function `name`.
+            /// This will be used by a [Reference][google.api.expr.v1alpha1.Reference]
+            /// to indicate the `overload_id` that was resolved for the function
+            /// `name`.
             /// </summary>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -3253,7 +3340,8 @@ namespace Google.Api.Expr.V1Alpha1 {
                 = pb::FieldCodec.ForMessage(18, global::Google.Api.Expr.V1Alpha1.Type.Parser);
             private readonly pbc::RepeatedField<global::Google.Api.Expr.V1Alpha1.Type> params_ = new pbc::RepeatedField<global::Google.Api.Expr.V1Alpha1.Type>();
             /// <summary>
-            /// List of function parameter [Type][google.api.expr.v1alpha1.Type] values.
+            /// List of function parameter [Type][google.api.expr.v1alpha1.Type]
+            /// values.
             ///
             /// Param types are disjoint after generic type parameters have been
             /// replaced with the type `DYN`. Since the `DYN` type is compatible with
@@ -3666,7 +3754,8 @@ namespace Google.Api.Expr.V1Alpha1 {
     /// presented candidates must happen at runtime because of dynamic types. The
     /// type checker attempts to narrow down this list as much as possible.
     ///
-    /// Empty if this is not a reference to a [Decl.FunctionDecl][google.api.expr.v1alpha1.Decl.FunctionDecl].
+    /// Empty if this is not a reference to a
+    /// [Decl.FunctionDecl][google.api.expr.v1alpha1.Decl.FunctionDecl].
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]

--- a/src/Sdk/Google/Api/Expr/V1Alpha1/Syntax.g.cs
+++ b/src/Sdk/Google/Api/Expr/V1Alpha1/Syntax.g.cs
@@ -30,7 +30,7 @@ namespace Google.Api.Expr.V1Alpha1 {
             "L3Byb3RvYnVmL3RpbWVzdGFtcC5wcm90byKHAQoKUGFyc2VkRXhwchIyCgRl",
             "eHByGAIgASgLMh4uZ29vZ2xlLmFwaS5leHByLnYxYWxwaGExLkV4cHJSBGV4",
             "cHISRQoLc291cmNlX2luZm8YAyABKAsyJC5nb29nbGUuYXBpLmV4cHIudjFh",
-            "bHBoYTEuU291cmNlSW5mb1IKc291cmNlSW5mbyLcDAoERXhwchIOCgJpZBgC",
+            "bHBoYTEuU291cmNlSW5mb1IKc291cmNlSW5mbyKuDQoERXhwchIOCgJpZBgC",
             "IAEoA1ICaWQSQwoKY29uc3RfZXhwchgDIAEoCzIiLmdvb2dsZS5hcGkuZXhw",
             "ci52MWFscGhhMS5Db25zdGFudEgAUgljb25zdEV4cHISRQoKaWRlbnRfZXhw",
             "chgEIAEoCzIkLmdvb2dsZS5hcGkuZXhwci52MWFscGhhMS5FeHByLklkZW50",
@@ -49,49 +49,51 @@ namespace Google.Api.Expr.V1Alpha1 {
             "KAhSCHRlc3RPbmx5Go4BCgRDYWxsEjYKBnRhcmdldBgBIAEoCzIeLmdvb2ds",
             "ZS5hcGkuZXhwci52MWFscGhhMS5FeHByUgZ0YXJnZXQSGgoIZnVuY3Rpb24Y",
             "AiABKAlSCGZ1bmN0aW9uEjIKBGFyZ3MYAyADKAsyHi5nb29nbGUuYXBpLmV4",
-            "cHIudjFhbHBoYTEuRXhwclIEYXJncxpICgpDcmVhdGVMaXN0EjoKCGVsZW1l",
+            "cHIudjFhbHBoYTEuRXhwclIEYXJncxpzCgpDcmVhdGVMaXN0EjoKCGVsZW1l",
             "bnRzGAEgAygLMh4uZ29vZ2xlLmFwaS5leHByLnYxYWxwaGExLkV4cHJSCGVs",
-            "ZW1lbnRzGrQCCgxDcmVhdGVTdHJ1Y3QSIQoMbWVzc2FnZV9uYW1lGAEgASgJ",
-            "UgttZXNzYWdlTmFtZRJLCgdlbnRyaWVzGAIgAygLMjEuZ29vZ2xlLmFwaS5l",
-            "eHByLnYxYWxwaGExLkV4cHIuQ3JlYXRlU3RydWN0LkVudHJ5UgdlbnRyaWVz",
-            "GrMBCgVFbnRyeRIOCgJpZBgBIAEoA1ICaWQSHQoJZmllbGRfa2V5GAIgASgJ",
-            "SABSCGZpZWxkS2V5EjkKB21hcF9rZXkYAyABKAsyHi5nb29nbGUuYXBpLmV4",
-            "cHIudjFhbHBoYTEuRXhwckgAUgZtYXBLZXkSNAoFdmFsdWUYBCABKAsyHi5n",
-            "b29nbGUuYXBpLmV4cHIudjFhbHBoYTEuRXhwclIFdmFsdWVCCgoIa2V5X2tp",
-            "bmQa/QIKDUNvbXByZWhlbnNpb24SGQoIaXRlcl92YXIYASABKAlSB2l0ZXJW",
-            "YXISPQoKaXRlcl9yYW5nZRgCIAEoCzIeLmdvb2dsZS5hcGkuZXhwci52MWFs",
-            "cGhhMS5FeHByUglpdGVyUmFuZ2USGQoIYWNjdV92YXIYAyABKAlSB2FjY3VW",
-            "YXISOwoJYWNjdV9pbml0GAQgASgLMh4uZ29vZ2xlLmFwaS5leHByLnYxYWxw",
-            "aGExLkV4cHJSCGFjY3VJbml0EkUKDmxvb3BfY29uZGl0aW9uGAUgASgLMh4u",
-            "Z29vZ2xlLmFwaS5leHByLnYxYWxwaGExLkV4cHJSDWxvb3BDb25kaXRpb24S",
-            "OwoJbG9vcF9zdGVwGAYgASgLMh4uZ29vZ2xlLmFwaS5leHByLnYxYWxwaGEx",
-            "LkV4cHJSCGxvb3BTdGVwEjYKBnJlc3VsdBgHIAEoCzIeLmdvb2dsZS5hcGku",
-            "ZXhwci52MWFscGhhMS5FeHByUgZyZXN1bHRCCwoJZXhwcl9raW5kIsEDCghD",
-            "b25zdGFudBI7CgpudWxsX3ZhbHVlGAEgASgOMhouZ29vZ2xlLnByb3RvYnVm",
-            "Lk51bGxWYWx1ZUgAUgludWxsVmFsdWUSHwoKYm9vbF92YWx1ZRgCIAEoCEgA",
-            "Uglib29sVmFsdWUSIQoLaW50NjRfdmFsdWUYAyABKANIAFIKaW50NjRWYWx1",
-            "ZRIjCgx1aW50NjRfdmFsdWUYBCABKARIAFILdWludDY0VmFsdWUSIwoMZG91",
-            "YmxlX3ZhbHVlGAUgASgBSABSC2RvdWJsZVZhbHVlEiMKDHN0cmluZ192YWx1",
-            "ZRgGIAEoCUgAUgtzdHJpbmdWYWx1ZRIhCgtieXRlc192YWx1ZRgHIAEoDEgA",
-            "UgpieXRlc1ZhbHVlEkYKDmR1cmF0aW9uX3ZhbHVlGAggASgLMhkuZ29vZ2xl",
-            "LnByb3RvYnVmLkR1cmF0aW9uQgIYAUgAUg1kdXJhdGlvblZhbHVlEkkKD3Rp",
-            "bWVzdGFtcF92YWx1ZRgJIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3Rh",
-            "bXBCAhgBSABSDnRpbWVzdGFtcFZhbHVlQg8KDWNvbnN0YW50X2tpbmQiuQMK",
-            "ClNvdXJjZUluZm8SJQoOc3ludGF4X3ZlcnNpb24YASABKAlSDXN5bnRheFZl",
-            "cnNpb24SGgoIbG9jYXRpb24YAiABKAlSCGxvY2F0aW9uEiEKDGxpbmVfb2Zm",
-            "c2V0cxgDIAMoBVILbGluZU9mZnNldHMSUQoJcG9zaXRpb25zGAQgAygLMjMu",
-            "Z29vZ2xlLmFwaS5leHByLnYxYWxwaGExLlNvdXJjZUluZm8uUG9zaXRpb25z",
-            "RW50cnlSCXBvc2l0aW9ucxJVCgttYWNyb19jYWxscxgFIAMoCzI0Lmdvb2ds",
-            "ZS5hcGkuZXhwci52MWFscGhhMS5Tb3VyY2VJbmZvLk1hY3JvQ2FsbHNFbnRy",
-            "eVIKbWFjcm9DYWxscxo8Cg5Qb3NpdGlvbnNFbnRyeRIQCgNrZXkYASABKANS",
-            "A2tleRIUCgV2YWx1ZRgCIAEoBVIFdmFsdWU6AjgBGl0KD01hY3JvQ2FsbHNF",
-            "bnRyeRIQCgNrZXkYASABKANSA2tleRI0CgV2YWx1ZRgCIAEoCzIeLmdvb2ds",
-            "ZS5hcGkuZXhwci52MWFscGhhMS5FeHByUgV2YWx1ZToCOAEicAoOU291cmNl",
-            "UG9zaXRpb24SGgoIbG9jYXRpb24YASABKAlSCGxvY2F0aW9uEhYKBm9mZnNl",
-            "dBgCIAEoBVIGb2Zmc2V0EhIKBGxpbmUYAyABKAVSBGxpbmUSFgoGY29sdW1u",
-            "GAQgASgFUgZjb2x1bW5CbgocY29tLmdvb2dsZS5hcGkuZXhwci52MWFscGhh",
-            "MUILU3ludGF4UHJvdG9QAVo8Z29vZ2xlLmdvbGFuZy5vcmcvZ2VucHJvdG8v",
-            "Z29vZ2xlYXBpcy9hcGkvZXhwci92MWFscGhhMTtleHBy+AEBYgZwcm90bzM="));
+            "ZW1lbnRzEikKEG9wdGlvbmFsX2luZGljZXMYAiADKAVSD29wdGlvbmFsSW5k",
+            "aWNlcxrbAgoMQ3JlYXRlU3RydWN0EiEKDG1lc3NhZ2VfbmFtZRgBIAEoCVIL",
+            "bWVzc2FnZU5hbWUSSwoHZW50cmllcxgCIAMoCzIxLmdvb2dsZS5hcGkuZXhw",
+            "ci52MWFscGhhMS5FeHByLkNyZWF0ZVN0cnVjdC5FbnRyeVIHZW50cmllcxra",
+            "AQoFRW50cnkSDgoCaWQYASABKANSAmlkEh0KCWZpZWxkX2tleRgCIAEoCUgA",
+            "UghmaWVsZEtleRI5CgdtYXBfa2V5GAMgASgLMh4uZ29vZ2xlLmFwaS5leHBy",
+            "LnYxYWxwaGExLkV4cHJIAFIGbWFwS2V5EjQKBXZhbHVlGAQgASgLMh4uZ29v",
+            "Z2xlLmFwaS5leHByLnYxYWxwaGExLkV4cHJSBXZhbHVlEiUKDm9wdGlvbmFs",
+            "X2VudHJ5GAUgASgIUg1vcHRpb25hbEVudHJ5QgoKCGtleV9raW5kGv0CCg1D",
+            "b21wcmVoZW5zaW9uEhkKCGl0ZXJfdmFyGAEgASgJUgdpdGVyVmFyEj0KCml0",
+            "ZXJfcmFuZ2UYAiABKAsyHi5nb29nbGUuYXBpLmV4cHIudjFhbHBoYTEuRXhw",
+            "clIJaXRlclJhbmdlEhkKCGFjY3VfdmFyGAMgASgJUgdhY2N1VmFyEjsKCWFj",
+            "Y3VfaW5pdBgEIAEoCzIeLmdvb2dsZS5hcGkuZXhwci52MWFscGhhMS5FeHBy",
+            "UghhY2N1SW5pdBJFCg5sb29wX2NvbmRpdGlvbhgFIAEoCzIeLmdvb2dsZS5h",
+            "cGkuZXhwci52MWFscGhhMS5FeHByUg1sb29wQ29uZGl0aW9uEjsKCWxvb3Bf",
+            "c3RlcBgGIAEoCzIeLmdvb2dsZS5hcGkuZXhwci52MWFscGhhMS5FeHByUghs",
+            "b29wU3RlcBI2CgZyZXN1bHQYByABKAsyHi5nb29nbGUuYXBpLmV4cHIudjFh",
+            "bHBoYTEuRXhwclIGcmVzdWx0QgsKCWV4cHJfa2luZCLBAwoIQ29uc3RhbnQS",
+            "OwoKbnVsbF92YWx1ZRgBIAEoDjIaLmdvb2dsZS5wcm90b2J1Zi5OdWxsVmFs",
+            "dWVIAFIJbnVsbFZhbHVlEh8KCmJvb2xfdmFsdWUYAiABKAhIAFIJYm9vbFZh",
+            "bHVlEiEKC2ludDY0X3ZhbHVlGAMgASgDSABSCmludDY0VmFsdWUSIwoMdWlu",
+            "dDY0X3ZhbHVlGAQgASgESABSC3VpbnQ2NFZhbHVlEiMKDGRvdWJsZV92YWx1",
+            "ZRgFIAEoAUgAUgtkb3VibGVWYWx1ZRIjCgxzdHJpbmdfdmFsdWUYBiABKAlI",
+            "AFILc3RyaW5nVmFsdWUSIQoLYnl0ZXNfdmFsdWUYByABKAxIAFIKYnl0ZXNW",
+            "YWx1ZRJGCg5kdXJhdGlvbl92YWx1ZRgIIAEoCzIZLmdvb2dsZS5wcm90b2J1",
+            "Zi5EdXJhdGlvbkICGAFIAFINZHVyYXRpb25WYWx1ZRJJCg90aW1lc3RhbXBf",
+            "dmFsdWUYCSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wQgIYAUgA",
+            "Ug50aW1lc3RhbXBWYWx1ZUIPCg1jb25zdGFudF9raW5kIrkDCgpTb3VyY2VJ",
+            "bmZvEiUKDnN5bnRheF92ZXJzaW9uGAEgASgJUg1zeW50YXhWZXJzaW9uEhoK",
+            "CGxvY2F0aW9uGAIgASgJUghsb2NhdGlvbhIhCgxsaW5lX29mZnNldHMYAyAD",
+            "KAVSC2xpbmVPZmZzZXRzElEKCXBvc2l0aW9ucxgEIAMoCzIzLmdvb2dsZS5h",
+            "cGkuZXhwci52MWFscGhhMS5Tb3VyY2VJbmZvLlBvc2l0aW9uc0VudHJ5Uglw",
+            "b3NpdGlvbnMSVQoLbWFjcm9fY2FsbHMYBSADKAsyNC5nb29nbGUuYXBpLmV4",
+            "cHIudjFhbHBoYTEuU291cmNlSW5mby5NYWNyb0NhbGxzRW50cnlSCm1hY3Jv",
+            "Q2FsbHMaPAoOUG9zaXRpb25zRW50cnkSEAoDa2V5GAEgASgDUgNrZXkSFAoF",
+            "dmFsdWUYAiABKAVSBXZhbHVlOgI4ARpdCg9NYWNyb0NhbGxzRW50cnkSEAoD",
+            "a2V5GAEgASgDUgNrZXkSNAoFdmFsdWUYAiABKAsyHi5nb29nbGUuYXBpLmV4",
+            "cHIudjFhbHBoYTEuRXhwclIFdmFsdWU6AjgBInAKDlNvdXJjZVBvc2l0aW9u",
+            "EhoKCGxvY2F0aW9uGAEgASgJUghsb2NhdGlvbhIWCgZvZmZzZXQYAiABKAVS",
+            "Bm9mZnNldBISCgRsaW5lGAMgASgFUgRsaW5lEhYKBmNvbHVtbhgEIAEoBVIG",
+            "Y29sdW1uQm4KHGNvbS5nb29nbGUuYXBpLmV4cHIudjFhbHBoYTFCC1N5bnRh",
+            "eFByb3RvUAFaPGdvb2dsZS5nb2xhbmcub3JnL2dlbnByb3RvL2dvb2dsZWFw",
+            "aXMvYXBpL2V4cHIvdjFhbHBoYTE7ZXhwcvgBAWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -99,8 +101,8 @@ namespace Google.Api.Expr.V1Alpha1 {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr), global::Google.Api.Expr.V1Alpha1.Expr.Parser, new[]{ "Id", "ConstExpr", "IdentExpr", "SelectExpr", "CallExpr", "ListExpr", "StructExpr", "ComprehensionExpr" }, new[]{ "ExprKind" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.Ident), global::Google.Api.Expr.V1Alpha1.Expr.Types.Ident.Parser, new[]{ "Name" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.Select), global::Google.Api.Expr.V1Alpha1.Expr.Types.Select.Parser, new[]{ "Operand", "Field", "TestOnly" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.Call), global::Google.Api.Expr.V1Alpha1.Expr.Types.Call.Parser, new[]{ "Target", "Function", "Args" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateList), global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateList.Parser, new[]{ "Elements" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct), global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct.Parser, new[]{ "MessageName", "Entries" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct.Types.Entry), global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct.Types.Entry.Parser, new[]{ "Id", "FieldKey", "MapKey", "Value" }, new[]{ "KeyKind" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateList), global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateList.Parser, new[]{ "Elements", "OptionalIndices" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct), global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct.Parser, new[]{ "MessageName", "Entries" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct.Types.Entry), global::Google.Api.Expr.V1Alpha1.Expr.Types.CreateStruct.Types.Entry.Parser, new[]{ "Id", "FieldKey", "MapKey", "Value", "OptionalEntry" }, new[]{ "KeyKind" }, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Expr.Types.Comprehension), global::Google.Api.Expr.V1Alpha1.Expr.Types.Comprehension.Parser, new[]{ "IterVar", "IterRange", "AccuVar", "AccuInit", "LoopCondition", "LoopStep", "Result" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.Constant), global::Google.Api.Expr.V1Alpha1.Constant.Parser, new[]{ "NullValue", "BoolValue", "Int64Value", "Uint64Value", "DoubleValue", "StringValue", "BytesValue", "DurationValue", "TimestampValue" }, new[]{ "ConstantKind" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Api.Expr.V1Alpha1.SourceInfo), global::Google.Api.Expr.V1Alpha1.SourceInfo.Parser, new[]{ "SyntaxVersion", "Location", "LineOffsets", "Positions", "MacroCalls" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
@@ -1804,6 +1806,7 @@ namespace Google.Api.Expr.V1Alpha1 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public CreateList(CreateList other) : this() {
           elements_ = other.elements_.Clone();
+          optionalIndices_ = other.optionalIndices_.Clone();
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -1827,6 +1830,25 @@ namespace Google.Api.Expr.V1Alpha1 {
           get { return elements_; }
         }
 
+        /// <summary>Field number for the "optional_indices" field.</summary>
+        public const int OptionalIndicesFieldNumber = 2;
+        private static readonly pb::FieldCodec<int> _repeated_optionalIndices_codec
+            = pb::FieldCodec.ForInt32(18);
+        private readonly pbc::RepeatedField<int> optionalIndices_ = new pbc::RepeatedField<int>();
+        /// <summary>
+        /// The indices within the elements list which are marked as optional
+        /// elements.
+        ///
+        /// When an optional-typed value is present, the value it contains
+        /// is included in the list. If the optional-typed value is absent, the list
+        /// element is omitted from the CreateList result.
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public pbc::RepeatedField<int> OptionalIndices {
+          get { return optionalIndices_; }
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -1843,6 +1865,7 @@ namespace Google.Api.Expr.V1Alpha1 {
             return true;
           }
           if(!elements_.Equals(other.elements_)) return false;
+          if(!optionalIndices_.Equals(other.optionalIndices_)) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -1851,6 +1874,7 @@ namespace Google.Api.Expr.V1Alpha1 {
         public override int GetHashCode() {
           int hash = 1;
           hash ^= elements_.GetHashCode();
+          hash ^= optionalIndices_.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -1870,6 +1894,7 @@ namespace Google.Api.Expr.V1Alpha1 {
           output.WriteRawMessage(this);
         #else
           elements_.WriteTo(output, _repeated_elements_codec);
+          optionalIndices_.WriteTo(output, _repeated_optionalIndices_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -1881,6 +1906,7 @@ namespace Google.Api.Expr.V1Alpha1 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
           elements_.WriteTo(ref output, _repeated_elements_codec);
+          optionalIndices_.WriteTo(ref output, _repeated_optionalIndices_codec);
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -1892,6 +1918,7 @@ namespace Google.Api.Expr.V1Alpha1 {
         public int CalculateSize() {
           int size = 0;
           size += elements_.CalculateSize(_repeated_elements_codec);
+          size += optionalIndices_.CalculateSize(_repeated_optionalIndices_codec);
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
           }
@@ -1905,6 +1932,7 @@ namespace Google.Api.Expr.V1Alpha1 {
             return;
           }
           elements_.Add(other.elements_);
+          optionalIndices_.Add(other.optionalIndices_);
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
 
@@ -1924,6 +1952,11 @@ namespace Google.Api.Expr.V1Alpha1 {
                 elements_.AddEntriesFrom(input, _repeated_elements_codec);
                 break;
               }
+              case 18:
+              case 16: {
+                optionalIndices_.AddEntriesFrom(input, _repeated_optionalIndices_codec);
+                break;
+              }
             }
           }
         #endif
@@ -1941,6 +1974,11 @@ namespace Google.Api.Expr.V1Alpha1 {
                 break;
               case 10: {
                 elements_.AddEntriesFrom(ref input, _repeated_elements_codec);
+                break;
+              }
+              case 18:
+              case 16: {
+                optionalIndices_.AddEntriesFrom(ref input, _repeated_optionalIndices_codec);
                 break;
               }
             }
@@ -2221,6 +2259,7 @@ namespace Google.Api.Expr.V1Alpha1 {
             public Entry(Entry other) : this() {
               id_ = other.id_;
               value_ = other.value_ != null ? other.value_.Clone() : null;
+              optionalEntry_ = other.optionalEntry_;
               switch (other.KeyKindCase) {
                 case KeyKindOneofCase.FieldKey:
                   FieldKey = other.FieldKey;
@@ -2264,10 +2303,24 @@ namespace Google.Api.Expr.V1Alpha1 {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
             public string FieldKey {
-              get { return keyKindCase_ == KeyKindOneofCase.FieldKey ? (string) keyKind_ : ""; }
+              get { return HasFieldKey ? (string) keyKind_ : ""; }
               set {
                 keyKind_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
                 keyKindCase_ = KeyKindOneofCase.FieldKey;
+              }
+            }
+            /// <summary>Gets whether the "field_key" field is set</summary>
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public bool HasFieldKey {
+              get { return keyKindCase_ == KeyKindOneofCase.FieldKey; }
+            }
+            /// <summary> Clears the value of the oneof if it's currently set to "field_key" </summary>
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void ClearFieldKey() {
+              if (HasFieldKey) {
+                ClearKeyKind();
               }
             }
 
@@ -2291,6 +2344,10 @@ namespace Google.Api.Expr.V1Alpha1 {
             private global::Google.Api.Expr.V1Alpha1.Expr value_;
             /// <summary>
             /// Required. The value assigned to the key.
+            ///
+            /// If the optional_entry field is true, the expression must resolve to an
+            /// optional-typed value. If the optional value is present, the key will be
+            /// set; however, if the optional value is absent, the key will be unset.
             /// </summary>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -2298,6 +2355,21 @@ namespace Google.Api.Expr.V1Alpha1 {
               get { return value_; }
               set {
                 value_ = value;
+              }
+            }
+
+            /// <summary>Field number for the "optional_entry" field.</summary>
+            public const int OptionalEntryFieldNumber = 5;
+            private bool optionalEntry_;
+            /// <summary>
+            /// Whether the key-value pair is optional.
+            /// </summary>
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public bool OptionalEntry {
+              get { return optionalEntry_; }
+              set {
+                optionalEntry_ = value;
               }
             }
 
@@ -2341,6 +2413,7 @@ namespace Google.Api.Expr.V1Alpha1 {
               if (FieldKey != other.FieldKey) return false;
               if (!object.Equals(MapKey, other.MapKey)) return false;
               if (!object.Equals(Value, other.Value)) return false;
+              if (OptionalEntry != other.OptionalEntry) return false;
               if (KeyKindCase != other.KeyKindCase) return false;
               return Equals(_unknownFields, other._unknownFields);
             }
@@ -2350,9 +2423,10 @@ namespace Google.Api.Expr.V1Alpha1 {
             public override int GetHashCode() {
               int hash = 1;
               if (Id != 0L) hash ^= Id.GetHashCode();
-              if (keyKindCase_ == KeyKindOneofCase.FieldKey) hash ^= FieldKey.GetHashCode();
+              if (HasFieldKey) hash ^= FieldKey.GetHashCode();
               if (keyKindCase_ == KeyKindOneofCase.MapKey) hash ^= MapKey.GetHashCode();
               if (value_ != null) hash ^= Value.GetHashCode();
+              if (OptionalEntry != false) hash ^= OptionalEntry.GetHashCode();
               hash ^= (int) keyKindCase_;
               if (_unknownFields != null) {
                 hash ^= _unknownFields.GetHashCode();
@@ -2376,7 +2450,7 @@ namespace Google.Api.Expr.V1Alpha1 {
                 output.WriteRawTag(8);
                 output.WriteInt64(Id);
               }
-              if (keyKindCase_ == KeyKindOneofCase.FieldKey) {
+              if (HasFieldKey) {
                 output.WriteRawTag(18);
                 output.WriteString(FieldKey);
               }
@@ -2387,6 +2461,10 @@ namespace Google.Api.Expr.V1Alpha1 {
               if (value_ != null) {
                 output.WriteRawTag(34);
                 output.WriteMessage(Value);
+              }
+              if (OptionalEntry != false) {
+                output.WriteRawTag(40);
+                output.WriteBool(OptionalEntry);
               }
               if (_unknownFields != null) {
                 _unknownFields.WriteTo(output);
@@ -2402,7 +2480,7 @@ namespace Google.Api.Expr.V1Alpha1 {
                 output.WriteRawTag(8);
                 output.WriteInt64(Id);
               }
-              if (keyKindCase_ == KeyKindOneofCase.FieldKey) {
+              if (HasFieldKey) {
                 output.WriteRawTag(18);
                 output.WriteString(FieldKey);
               }
@@ -2413,6 +2491,10 @@ namespace Google.Api.Expr.V1Alpha1 {
               if (value_ != null) {
                 output.WriteRawTag(34);
                 output.WriteMessage(Value);
+              }
+              if (OptionalEntry != false) {
+                output.WriteRawTag(40);
+                output.WriteBool(OptionalEntry);
               }
               if (_unknownFields != null) {
                 _unknownFields.WriteTo(ref output);
@@ -2427,7 +2509,7 @@ namespace Google.Api.Expr.V1Alpha1 {
               if (Id != 0L) {
                 size += 1 + pb::CodedOutputStream.ComputeInt64Size(Id);
               }
-              if (keyKindCase_ == KeyKindOneofCase.FieldKey) {
+              if (HasFieldKey) {
                 size += 1 + pb::CodedOutputStream.ComputeStringSize(FieldKey);
               }
               if (keyKindCase_ == KeyKindOneofCase.MapKey) {
@@ -2435,6 +2517,9 @@ namespace Google.Api.Expr.V1Alpha1 {
               }
               if (value_ != null) {
                 size += 1 + pb::CodedOutputStream.ComputeMessageSize(Value);
+              }
+              if (OptionalEntry != false) {
+                size += 1 + 1;
               }
               if (_unknownFields != null) {
                 size += _unknownFields.CalculateSize();
@@ -2456,6 +2541,9 @@ namespace Google.Api.Expr.V1Alpha1 {
                   Value = new global::Google.Api.Expr.V1Alpha1.Expr();
                 }
                 Value.MergeFrom(other.Value);
+              }
+              if (other.OptionalEntry != false) {
+                OptionalEntry = other.OptionalEntry;
               }
               switch (other.KeyKindCase) {
                 case KeyKindOneofCase.FieldKey:
@@ -2508,6 +2596,10 @@ namespace Google.Api.Expr.V1Alpha1 {
                     input.ReadMessage(Value);
                     break;
                   }
+                  case 40: {
+                    OptionalEntry = input.ReadBool();
+                    break;
+                  }
                 }
               }
             #endif
@@ -2545,6 +2637,10 @@ namespace Google.Api.Expr.V1Alpha1 {
                       Value = new global::Google.Api.Expr.V1Alpha1.Expr();
                     }
                     input.ReadMessage(Value);
+                    break;
+                  }
+                  case 40: {
+                    OptionalEntry = input.ReadBool();
                     break;
                   }
                 }
@@ -3172,10 +3268,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Google.Protobuf.WellKnownTypes.NullValue NullValue {
-      get { return constantKindCase_ == ConstantKindOneofCase.NullValue ? (global::Google.Protobuf.WellKnownTypes.NullValue) constantKind_ : global::Google.Protobuf.WellKnownTypes.NullValue.NullValue; }
+      get { return HasNullValue ? (global::Google.Protobuf.WellKnownTypes.NullValue) constantKind_ : global::Google.Protobuf.WellKnownTypes.NullValue.NullValue; }
       set {
         constantKind_ = value;
         constantKindCase_ = ConstantKindOneofCase.NullValue;
+      }
+    }
+    /// <summary>Gets whether the "null_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasNullValue {
+      get { return constantKindCase_ == ConstantKindOneofCase.NullValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "null_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearNullValue() {
+      if (HasNullValue) {
+        ClearConstantKind();
       }
     }
 
@@ -3187,10 +3297,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool BoolValue {
-      get { return constantKindCase_ == ConstantKindOneofCase.BoolValue ? (bool) constantKind_ : false; }
+      get { return HasBoolValue ? (bool) constantKind_ : false; }
       set {
         constantKind_ = value;
         constantKindCase_ = ConstantKindOneofCase.BoolValue;
+      }
+    }
+    /// <summary>Gets whether the "bool_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasBoolValue {
+      get { return constantKindCase_ == ConstantKindOneofCase.BoolValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "bool_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearBoolValue() {
+      if (HasBoolValue) {
+        ClearConstantKind();
       }
     }
 
@@ -3202,10 +3326,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public long Int64Value {
-      get { return constantKindCase_ == ConstantKindOneofCase.Int64Value ? (long) constantKind_ : 0L; }
+      get { return HasInt64Value ? (long) constantKind_ : 0L; }
       set {
         constantKind_ = value;
         constantKindCase_ = ConstantKindOneofCase.Int64Value;
+      }
+    }
+    /// <summary>Gets whether the "int64_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasInt64Value {
+      get { return constantKindCase_ == ConstantKindOneofCase.Int64Value; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "int64_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearInt64Value() {
+      if (HasInt64Value) {
+        ClearConstantKind();
       }
     }
 
@@ -3217,10 +3355,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ulong Uint64Value {
-      get { return constantKindCase_ == ConstantKindOneofCase.Uint64Value ? (ulong) constantKind_ : 0UL; }
+      get { return HasUint64Value ? (ulong) constantKind_ : 0UL; }
       set {
         constantKind_ = value;
         constantKindCase_ = ConstantKindOneofCase.Uint64Value;
+      }
+    }
+    /// <summary>Gets whether the "uint64_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasUint64Value {
+      get { return constantKindCase_ == ConstantKindOneofCase.Uint64Value; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "uint64_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearUint64Value() {
+      if (HasUint64Value) {
+        ClearConstantKind();
       }
     }
 
@@ -3232,10 +3384,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public double DoubleValue {
-      get { return constantKindCase_ == ConstantKindOneofCase.DoubleValue ? (double) constantKind_ : 0D; }
+      get { return HasDoubleValue ? (double) constantKind_ : 0D; }
       set {
         constantKind_ = value;
         constantKindCase_ = ConstantKindOneofCase.DoubleValue;
+      }
+    }
+    /// <summary>Gets whether the "double_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasDoubleValue {
+      get { return constantKindCase_ == ConstantKindOneofCase.DoubleValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "double_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearDoubleValue() {
+      if (HasDoubleValue) {
+        ClearConstantKind();
       }
     }
 
@@ -3247,10 +3413,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string StringValue {
-      get { return constantKindCase_ == ConstantKindOneofCase.StringValue ? (string) constantKind_ : ""; }
+      get { return HasStringValue ? (string) constantKind_ : ""; }
       set {
         constantKind_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         constantKindCase_ = ConstantKindOneofCase.StringValue;
+      }
+    }
+    /// <summary>Gets whether the "string_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasStringValue {
+      get { return constantKindCase_ == ConstantKindOneofCase.StringValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "string_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearStringValue() {
+      if (HasStringValue) {
+        ClearConstantKind();
       }
     }
 
@@ -3262,10 +3442,24 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pb::ByteString BytesValue {
-      get { return constantKindCase_ == ConstantKindOneofCase.BytesValue ? (pb::ByteString) constantKind_ : pb::ByteString.Empty; }
+      get { return HasBytesValue ? (pb::ByteString) constantKind_ : pb::ByteString.Empty; }
       set {
         constantKind_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         constantKindCase_ = ConstantKindOneofCase.BytesValue;
+      }
+    }
+    /// <summary>Gets whether the "bytes_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasBytesValue {
+      get { return constantKindCase_ == ConstantKindOneofCase.BytesValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "bytes_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearBytesValue() {
+      if (HasBytesValue) {
+        ClearConstantKind();
       }
     }
 
@@ -3365,13 +3559,13 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (constantKindCase_ == ConstantKindOneofCase.NullValue) hash ^= NullValue.GetHashCode();
-      if (constantKindCase_ == ConstantKindOneofCase.BoolValue) hash ^= BoolValue.GetHashCode();
-      if (constantKindCase_ == ConstantKindOneofCase.Int64Value) hash ^= Int64Value.GetHashCode();
-      if (constantKindCase_ == ConstantKindOneofCase.Uint64Value) hash ^= Uint64Value.GetHashCode();
-      if (constantKindCase_ == ConstantKindOneofCase.DoubleValue) hash ^= pbc::ProtobufEqualityComparers.BitwiseDoubleEqualityComparer.GetHashCode(DoubleValue);
-      if (constantKindCase_ == ConstantKindOneofCase.StringValue) hash ^= StringValue.GetHashCode();
-      if (constantKindCase_ == ConstantKindOneofCase.BytesValue) hash ^= BytesValue.GetHashCode();
+      if (HasNullValue) hash ^= NullValue.GetHashCode();
+      if (HasBoolValue) hash ^= BoolValue.GetHashCode();
+      if (HasInt64Value) hash ^= Int64Value.GetHashCode();
+      if (HasUint64Value) hash ^= Uint64Value.GetHashCode();
+      if (HasDoubleValue) hash ^= pbc::ProtobufEqualityComparers.BitwiseDoubleEqualityComparer.GetHashCode(DoubleValue);
+      if (HasStringValue) hash ^= StringValue.GetHashCode();
+      if (HasBytesValue) hash ^= BytesValue.GetHashCode();
       if (constantKindCase_ == ConstantKindOneofCase.DurationValue) hash ^= DurationValue.GetHashCode();
       if (constantKindCase_ == ConstantKindOneofCase.TimestampValue) hash ^= TimestampValue.GetHashCode();
       hash ^= (int) constantKindCase_;
@@ -3393,31 +3587,31 @@ namespace Google.Api.Expr.V1Alpha1 {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (constantKindCase_ == ConstantKindOneofCase.NullValue) {
+      if (HasNullValue) {
         output.WriteRawTag(8);
         output.WriteEnum((int) NullValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.BoolValue) {
+      if (HasBoolValue) {
         output.WriteRawTag(16);
         output.WriteBool(BoolValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.Int64Value) {
+      if (HasInt64Value) {
         output.WriteRawTag(24);
         output.WriteInt64(Int64Value);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.Uint64Value) {
+      if (HasUint64Value) {
         output.WriteRawTag(32);
         output.WriteUInt64(Uint64Value);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.DoubleValue) {
+      if (HasDoubleValue) {
         output.WriteRawTag(41);
         output.WriteDouble(DoubleValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.StringValue) {
+      if (HasStringValue) {
         output.WriteRawTag(50);
         output.WriteString(StringValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.BytesValue) {
+      if (HasBytesValue) {
         output.WriteRawTag(58);
         output.WriteBytes(BytesValue);
       }
@@ -3439,31 +3633,31 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (constantKindCase_ == ConstantKindOneofCase.NullValue) {
+      if (HasNullValue) {
         output.WriteRawTag(8);
         output.WriteEnum((int) NullValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.BoolValue) {
+      if (HasBoolValue) {
         output.WriteRawTag(16);
         output.WriteBool(BoolValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.Int64Value) {
+      if (HasInt64Value) {
         output.WriteRawTag(24);
         output.WriteInt64(Int64Value);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.Uint64Value) {
+      if (HasUint64Value) {
         output.WriteRawTag(32);
         output.WriteUInt64(Uint64Value);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.DoubleValue) {
+      if (HasDoubleValue) {
         output.WriteRawTag(41);
         output.WriteDouble(DoubleValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.StringValue) {
+      if (HasStringValue) {
         output.WriteRawTag(50);
         output.WriteString(StringValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.BytesValue) {
+      if (HasBytesValue) {
         output.WriteRawTag(58);
         output.WriteBytes(BytesValue);
       }
@@ -3485,25 +3679,25 @@ namespace Google.Api.Expr.V1Alpha1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (constantKindCase_ == ConstantKindOneofCase.NullValue) {
+      if (HasNullValue) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) NullValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.BoolValue) {
+      if (HasBoolValue) {
         size += 1 + 1;
       }
-      if (constantKindCase_ == ConstantKindOneofCase.Int64Value) {
+      if (HasInt64Value) {
         size += 1 + pb::CodedOutputStream.ComputeInt64Size(Int64Value);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.Uint64Value) {
+      if (HasUint64Value) {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(Uint64Value);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.DoubleValue) {
+      if (HasDoubleValue) {
         size += 1 + 8;
       }
-      if (constantKindCase_ == ConstantKindOneofCase.StringValue) {
+      if (HasStringValue) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(StringValue);
       }
-      if (constantKindCase_ == ConstantKindOneofCase.BytesValue) {
+      if (HasBytesValue) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(BytesValue);
       }
       if (constantKindCase_ == ConstantKindOneofCase.DurationValue) {
@@ -3951,8 +4145,8 @@ namespace Google.Api.Expr.V1Alpha1 {
         Location = other.Location;
       }
       lineOffsets_.Add(other.lineOffsets_);
-      positions_.Add(other.positions_);
-      macroCalls_.Add(other.macroCalls_);
+      positions_.MergeFrom(other.positions_);
+      macroCalls_.MergeFrom(other.macroCalls_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 

--- a/src/Sdk/Google/Api/Http.g.cs
+++ b/src/Sdk/Google/Api/Http.g.cs
@@ -454,15 +454,18 @@ namespace Google.Api {
   /// 1. Leaf request fields (recursive expansion nested messages in the request
   ///    message) are classified into three categories:
   ///    - Fields referred by the path template. They are passed via the URL path.
-  ///    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+  ///    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+  ///    are passed via the HTTP
   ///      request body.
   ///    - All other fields are passed via the URL query parameters, and the
   ///      parameter name is the field path in the request message. A repeated
   ///      field can be represented as multiple query parameters under the same
   ///      name.
-  ///  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+  ///  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+  ///  query parameter, all fields
   ///     are passed via URL path and HTTP request body.
-  ///  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+  ///  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+  ///  request body, all
   ///     fields are passed via URL path and URL query parameters.
   ///
   /// ### Path template syntax
@@ -629,7 +632,8 @@ namespace Google.Api {
     /// <summary>
     /// Selects a method to which this rule applies.
     ///
-    /// Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+    /// Refer to [selector][google.api.DocumentationRule.selector] for syntax
+    /// details.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -649,10 +653,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Get {
-      get { return patternCase_ == PatternOneofCase.Get ? (string) pattern_ : ""; }
+      get { return HasGet ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Get;
+      }
+    }
+    /// <summary>Gets whether the "get" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasGet {
+      get { return patternCase_ == PatternOneofCase.Get; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "get" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearGet() {
+      if (HasGet) {
+        ClearPattern();
       }
     }
 
@@ -664,10 +682,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Put {
-      get { return patternCase_ == PatternOneofCase.Put ? (string) pattern_ : ""; }
+      get { return HasPut ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Put;
+      }
+    }
+    /// <summary>Gets whether the "put" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPut {
+      get { return patternCase_ == PatternOneofCase.Put; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "put" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPut() {
+      if (HasPut) {
+        ClearPattern();
       }
     }
 
@@ -679,10 +711,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Post {
-      get { return patternCase_ == PatternOneofCase.Post ? (string) pattern_ : ""; }
+      get { return HasPost ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Post;
+      }
+    }
+    /// <summary>Gets whether the "post" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPost {
+      get { return patternCase_ == PatternOneofCase.Post; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "post" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPost() {
+      if (HasPost) {
+        ClearPattern();
       }
     }
 
@@ -694,10 +740,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Delete {
-      get { return patternCase_ == PatternOneofCase.Delete ? (string) pattern_ : ""; }
+      get { return HasDelete ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Delete;
+      }
+    }
+    /// <summary>Gets whether the "delete" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasDelete {
+      get { return patternCase_ == PatternOneofCase.Delete; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "delete" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearDelete() {
+      if (HasDelete) {
+        ClearPattern();
       }
     }
 
@@ -709,10 +769,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Patch {
-      get { return patternCase_ == PatternOneofCase.Patch ? (string) pattern_ : ""; }
+      get { return HasPatch ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Patch;
+      }
+    }
+    /// <summary>Gets whether the "patch" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPatch {
+      get { return patternCase_ == PatternOneofCase.Patch; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "patch" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPatch() {
+      if (HasPatch) {
+        ClearPattern();
       }
     }
 
@@ -849,11 +923,11 @@ namespace Google.Api {
     public override int GetHashCode() {
       int hash = 1;
       if (Selector.Length != 0) hash ^= Selector.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Get) hash ^= Get.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Put) hash ^= Put.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Post) hash ^= Post.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Delete) hash ^= Delete.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Patch) hash ^= Patch.GetHashCode();
+      if (HasGet) hash ^= Get.GetHashCode();
+      if (HasPut) hash ^= Put.GetHashCode();
+      if (HasPost) hash ^= Post.GetHashCode();
+      if (HasDelete) hash ^= Delete.GetHashCode();
+      if (HasPatch) hash ^= Patch.GetHashCode();
       if (patternCase_ == PatternOneofCase.Custom) hash ^= Custom.GetHashCode();
       if (Body.Length != 0) hash ^= Body.GetHashCode();
       if (ResponseBody.Length != 0) hash ^= ResponseBody.GetHashCode();
@@ -881,23 +955,23 @@ namespace Google.Api {
         output.WriteRawTag(10);
         output.WriteString(Selector);
       }
-      if (patternCase_ == PatternOneofCase.Get) {
+      if (HasGet) {
         output.WriteRawTag(18);
         output.WriteString(Get);
       }
-      if (patternCase_ == PatternOneofCase.Put) {
+      if (HasPut) {
         output.WriteRawTag(26);
         output.WriteString(Put);
       }
-      if (patternCase_ == PatternOneofCase.Post) {
+      if (HasPost) {
         output.WriteRawTag(34);
         output.WriteString(Post);
       }
-      if (patternCase_ == PatternOneofCase.Delete) {
+      if (HasDelete) {
         output.WriteRawTag(42);
         output.WriteString(Delete);
       }
-      if (patternCase_ == PatternOneofCase.Patch) {
+      if (HasPatch) {
         output.WriteRawTag(50);
         output.WriteString(Patch);
       }
@@ -928,23 +1002,23 @@ namespace Google.Api {
         output.WriteRawTag(10);
         output.WriteString(Selector);
       }
-      if (patternCase_ == PatternOneofCase.Get) {
+      if (HasGet) {
         output.WriteRawTag(18);
         output.WriteString(Get);
       }
-      if (patternCase_ == PatternOneofCase.Put) {
+      if (HasPut) {
         output.WriteRawTag(26);
         output.WriteString(Put);
       }
-      if (patternCase_ == PatternOneofCase.Post) {
+      if (HasPost) {
         output.WriteRawTag(34);
         output.WriteString(Post);
       }
-      if (patternCase_ == PatternOneofCase.Delete) {
+      if (HasDelete) {
         output.WriteRawTag(42);
         output.WriteString(Delete);
       }
-      if (patternCase_ == PatternOneofCase.Patch) {
+      if (HasPatch) {
         output.WriteRawTag(50);
         output.WriteString(Patch);
       }
@@ -974,19 +1048,19 @@ namespace Google.Api {
       if (Selector.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Selector);
       }
-      if (patternCase_ == PatternOneofCase.Get) {
+      if (HasGet) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Get);
       }
-      if (patternCase_ == PatternOneofCase.Put) {
+      if (HasPut) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Put);
       }
-      if (patternCase_ == PatternOneofCase.Post) {
+      if (HasPost) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Post);
       }
-      if (patternCase_ == PatternOneofCase.Delete) {
+      if (HasDelete) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Delete);
       }
-      if (patternCase_ == PatternOneofCase.Patch) {
+      if (HasPatch) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Patch);
       }
       if (patternCase_ == PatternOneofCase.Custom) {

--- a/src/Sdk/Google/Api/Visibility.g.cs
+++ b/src/Sdk/Google/Api/Visibility.g.cs
@@ -92,16 +92,17 @@ namespace Google.Api {
 
   #region Messages
   /// <summary>
-  /// `Visibility` defines restrictions for the visibility of service
-  /// elements.  Restrictions are specified using visibility labels
-  /// (e.g., PREVIEW) that are elsewhere linked to users and projects.
+  /// `Visibility` restricts service consumer's access to service elements,
+  /// such as whether an application can call a visibility-restricted method.
+  /// The restriction is expressed by applying visibility labels on service
+  /// elements. The visibility labels are elsewhere linked to service consumers.
   ///
-  /// Users and projects can have access to more than one visibility label. The
-  /// effective visibility for multiple labels is the union of each label's
-  /// elements, plus any unrestricted elements.
+  /// A service can define multiple visibility labels, but a service consumer
+  /// should be granted at most one visibility label. Multiple visibility
+  /// labels for a single service consumer are not supported.
   ///
-  /// If an element and its parents have no restrictions, visibility is
-  /// unconditionally granted.
+  /// If an element and all its parents have no visibility label, its visibility
+  /// is unconditionally granted.
   ///
   /// Example:
   ///
@@ -353,7 +354,8 @@ namespace Google.Api {
     /// <summary>
     /// Selects methods, messages, fields, enums, etc. to which this rule applies.
     ///
-    /// Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+    /// Refer to [selector][google.api.DocumentationRule.selector] for syntax
+    /// details.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]

--- a/src/Sdk/Grpc/Gateway/ProtocGenOpenapiv2/Options/Openapiv2.g.cs
+++ b/src/Sdk/Grpc/Gateway/ProtocGenOpenapiv2/Options/Openapiv2.g.cs
@@ -26,7 +26,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
           string.Concat(
             "Cixwcm90b2MtZ2VuLW9wZW5hcGl2Mi9vcHRpb25zL29wZW5hcGl2Mi5wcm90",
             "bxIpZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMa",
-            "HGdvb2dsZS9wcm90b2J1Zi9zdHJ1Y3QucHJvdG8i9QcKB1N3YWdnZXISGAoH",
+            "HGdvb2dsZS9wcm90b2J1Zi9zdHJ1Y3QucHJvdG8iswgKB1N3YWdnZXISGAoH",
             "c3dhZ2dlchgBIAEoCVIHc3dhZ2dlchJDCgRpbmZvGAIgASgLMi8uZ3JwYy5n",
             "YXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuSW5mb1IEaW5m",
             "bxISCgRob3N0GAMgASgJUgRob3N0EhsKCWJhc2VfcGF0aBgEIAEoCVIIYmFz",
@@ -39,157 +39,176 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
             "cGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlNlY3Vy",
             "aXR5RGVmaW5pdGlvbnNSE3NlY3VyaXR5RGVmaW5pdGlvbnMSWgoIc2VjdXJp",
             "dHkYDCADKAsyPi5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIu",
-            "b3B0aW9ucy5TZWN1cml0eVJlcXVpcmVtZW50UghzZWN1cml0eRJlCg1leHRl",
-            "cm5hbF9kb2NzGA4gASgLMkAuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3Bl",
-            "bmFwaXYyLm9wdGlvbnMuRXh0ZXJuYWxEb2N1bWVudGF0aW9uUgxleHRlcm5h",
-            "bERvY3MSYgoKZXh0ZW5zaW9ucxgPIAMoCzJCLmdycGMuZ2F0ZXdheS5wcm90",
-            "b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlN3YWdnZXIuRXh0ZW5zaW9uc0Vu",
-            "dHJ5UgpleHRlbnNpb25zGnEKDlJlc3BvbnNlc0VudHJ5EhAKA2tleRgBIAEo",
-            "CVIDa2V5EkkKBXZhbHVlGAIgASgLMjMuZ3JwYy5nYXRld2F5LnByb3RvY19n",
-            "ZW5fb3BlbmFwaXYyLm9wdGlvbnMuUmVzcG9uc2VSBXZhbHVlOgI4ARpVCg9F",
-            "eHRlbnNpb25zRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiAB",
-            "KAsyFi5nb29nbGUucHJvdG9idWYuVmFsdWVSBXZhbHVlOgI4AUoECAgQCUoE",
-            "CAkQCkoECA0QDiL/BgoJT3BlcmF0aW9uEhIKBHRhZ3MYASADKAlSBHRhZ3MS",
-            "GAoHc3VtbWFyeRgCIAEoCVIHc3VtbWFyeRIgCgtkZXNjcmlwdGlvbhgDIAEo",
-            "CVILZGVzY3JpcHRpb24SZQoNZXh0ZXJuYWxfZG9jcxgEIAEoCzJALmdycGMu",
-            "Z2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLkV4dGVybmFs",
-            "RG9jdW1lbnRhdGlvblIMZXh0ZXJuYWxEb2NzEiEKDG9wZXJhdGlvbl9pZBgF",
-            "IAEoCVILb3BlcmF0aW9uSWQSGgoIY29uc3VtZXMYBiADKAlSCGNvbnN1bWVz",
-            "EhoKCHByb2R1Y2VzGAcgAygJUghwcm9kdWNlcxJhCglyZXNwb25zZXMYCSAD",
-            "KAsyQy5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9u",
-            "cy5PcGVyYXRpb24uUmVzcG9uc2VzRW50cnlSCXJlc3BvbnNlcxJLCgdzY2hl",
-            "bWVzGAogAygOMjEuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYy",
-            "Lm9wdGlvbnMuU2NoZW1lUgdzY2hlbWVzEh4KCmRlcHJlY2F0ZWQYCyABKAhS",
-            "CmRlcHJlY2F0ZWQSWgoIc2VjdXJpdHkYDCADKAsyPi5ncnBjLmdhdGV3YXku",
-            "cHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5TZWN1cml0eVJlcXVpcmVt",
-            "ZW50UghzZWN1cml0eRJkCgpleHRlbnNpb25zGA0gAygLMkQuZ3JwYy5nYXRl",
-            "d2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuT3BlcmF0aW9uLkV4",
-            "dGVuc2lvbnNFbnRyeVIKZXh0ZW5zaW9ucxpxCg5SZXNwb25zZXNFbnRyeRIQ",
-            "CgNrZXkYASABKAlSA2tleRJJCgV2YWx1ZRgCIAEoCzIzLmdycGMuZ2F0ZXdh",
-            "eS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlJlc3BvbnNlUgV2YWx1",
-            "ZToCOAEaVQoPRXh0ZW5zaW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EiwK",
-            "BXZhbHVlGAIgASgLMhYuZ29vZ2xlLnByb3RvYnVmLlZhbHVlUgV2YWx1ZToC",
-            "OAFKBAgIEAki2AEKBkhlYWRlchIgCgtkZXNjcmlwdGlvbhgBIAEoCVILZGVz",
-            "Y3JpcHRpb24SEgoEdHlwZRgCIAEoCVIEdHlwZRIWCgZmb3JtYXQYAyABKAlS",
-            "BmZvcm1hdBIYCgdkZWZhdWx0GAYgASgJUgdkZWZhdWx0EhgKB3BhdHRlcm4Y",
-            "DSABKAlSB3BhdHRlcm5KBAgEEAVKBAgFEAZKBAgHEAhKBAgIEAlKBAgJEApK",
-            "BAgKEAtKBAgLEAxKBAgMEA1KBAgOEA9KBAgPEBBKBAgQEBFKBAgREBJKBAgS",
-            "EBMimgUKCFJlc3BvbnNlEiAKC2Rlc2NyaXB0aW9uGAEgASgJUgtkZXNjcmlw",
-            "dGlvbhJJCgZzY2hlbWEYAiABKAsyMS5ncnBjLmdhdGV3YXkucHJvdG9jX2dl",
-            "bl9vcGVuYXBpdjIub3B0aW9ucy5TY2hlbWFSBnNjaGVtYRJaCgdoZWFkZXJz",
-            "GAMgAygLMkAuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9w",
-            "dGlvbnMuUmVzcG9uc2UuSGVhZGVyc0VudHJ5UgdoZWFkZXJzEl0KCGV4YW1w",
-            "bGVzGAQgAygLMkEuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYy",
-            "Lm9wdGlvbnMuUmVzcG9uc2UuRXhhbXBsZXNFbnRyeVIIZXhhbXBsZXMSYwoK",
-            "ZXh0ZW5zaW9ucxgFIAMoCzJDLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29w",
-            "ZW5hcGl2Mi5vcHRpb25zLlJlc3BvbnNlLkV4dGVuc2lvbnNFbnRyeVIKZXh0",
-            "ZW5zaW9ucxptCgxIZWFkZXJzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSRwoF",
-            "dmFsdWUYAiABKAsyMS5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBp",
-            "djIub3B0aW9ucy5IZWFkZXJSBXZhbHVlOgI4ARo7Cg1FeGFtcGxlc0VudHJ5",
-            "EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEa",
-            "VQoPRXh0ZW5zaW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EiwKBXZhbHVl",
-            "GAIgASgLMhYuZ29vZ2xlLnByb3RvYnVmLlZhbHVlUgV2YWx1ZToCOAEi1gMK",
-            "BEluZm8SFAoFdGl0bGUYASABKAlSBXRpdGxlEiAKC2Rlc2NyaXB0aW9uGAIg",
-            "ASgJUgtkZXNjcmlwdGlvbhIoChB0ZXJtc19vZl9zZXJ2aWNlGAMgASgJUg50",
-            "ZXJtc09mU2VydmljZRJMCgdjb250YWN0GAQgASgLMjIuZ3JwYy5nYXRld2F5",
-            "LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuQ29udGFjdFIHY29udGFj",
-            "dBJMCgdsaWNlbnNlGAUgASgLMjIuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5f",
-            "b3BlbmFwaXYyLm9wdGlvbnMuTGljZW5zZVIHbGljZW5zZRIYCgd2ZXJzaW9u",
-            "GAYgASgJUgd2ZXJzaW9uEl8KCmV4dGVuc2lvbnMYByADKAsyPy5ncnBjLmdh",
-            "dGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5JbmZvLkV4dGVu",
-            "c2lvbnNFbnRyeVIKZXh0ZW5zaW9ucxpVCg9FeHRlbnNpb25zRW50cnkSEAoD",
-            "a2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiABKAsyFi5nb29nbGUucHJvdG9i",
-            "dWYuVmFsdWVSBXZhbHVlOgI4ASJFCgdDb250YWN0EhIKBG5hbWUYASABKAlS",
-            "BG5hbWUSEAoDdXJsGAIgASgJUgN1cmwSFAoFZW1haWwYAyABKAlSBWVtYWls",
-            "Ii8KB0xpY2Vuc2USEgoEbmFtZRgBIAEoCVIEbmFtZRIQCgN1cmwYAiABKAlS",
-            "A3VybCJLChVFeHRlcm5hbERvY3VtZW50YXRpb24SIAoLZGVzY3JpcHRpb24Y",
-            "ASABKAlSC2Rlc2NyaXB0aW9uEhAKA3VybBgCIAEoCVIDdXJsIqoCCgZTY2hl",
-            "bWESVgoLanNvbl9zY2hlbWEYASABKAsyNS5ncnBjLmdhdGV3YXkucHJvdG9j",
-            "X2dlbl9vcGVuYXBpdjIub3B0aW9ucy5KU09OU2NoZW1hUgpqc29uU2NoZW1h",
-            "EiQKDWRpc2NyaW1pbmF0b3IYAiABKAlSDWRpc2NyaW1pbmF0b3ISGwoJcmVh",
-            "ZF9vbmx5GAMgASgIUghyZWFkT25seRJlCg1leHRlcm5hbF9kb2NzGAUgASgL",
-            "MkAuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMu",
-            "RXh0ZXJuYWxEb2N1bWVudGF0aW9uUgxleHRlcm5hbERvY3MSGAoHZXhhbXBs",
-            "ZRgGIAEoCVIHZXhhbXBsZUoECAQQBSLXCgoKSlNPTlNjaGVtYRIQCgNyZWYY",
-            "AyABKAlSA3JlZhIUCgV0aXRsZRgFIAEoCVIFdGl0bGUSIAoLZGVzY3JpcHRp",
-            "b24YBiABKAlSC2Rlc2NyaXB0aW9uEhgKB2RlZmF1bHQYByABKAlSB2RlZmF1",
-            "bHQSGwoJcmVhZF9vbmx5GAggASgIUghyZWFkT25seRIYCgdleGFtcGxlGAkg",
-            "ASgJUgdleGFtcGxlEh8KC211bHRpcGxlX29mGAogASgBUgptdWx0aXBsZU9m",
-            "EhgKB21heGltdW0YCyABKAFSB21heGltdW0SKwoRZXhjbHVzaXZlX21heGlt",
-            "dW0YDCABKAhSEGV4Y2x1c2l2ZU1heGltdW0SGAoHbWluaW11bRgNIAEoAVIH",
-            "bWluaW11bRIrChFleGNsdXNpdmVfbWluaW11bRgOIAEoCFIQZXhjbHVzaXZl",
-            "TWluaW11bRIdCgptYXhfbGVuZ3RoGA8gASgEUgltYXhMZW5ndGgSHQoKbWlu",
-            "X2xlbmd0aBgQIAEoBFIJbWluTGVuZ3RoEhgKB3BhdHRlcm4YESABKAlSB3Bh",
-            "dHRlcm4SGwoJbWF4X2l0ZW1zGBQgASgEUghtYXhJdGVtcxIbCgltaW5faXRl",
-            "bXMYFSABKARSCG1pbkl0ZW1zEiEKDHVuaXF1ZV9pdGVtcxgWIAEoCFILdW5p",
-            "cXVlSXRlbXMSJQoObWF4X3Byb3BlcnRpZXMYGCABKARSDW1heFByb3BlcnRp",
-            "ZXMSJQoObWluX3Byb3BlcnRpZXMYGSABKARSDW1pblByb3BlcnRpZXMSGgoI",
-            "cmVxdWlyZWQYGiADKAlSCHJlcXVpcmVkEhQKBWFycmF5GCIgAygJUgVhcnJh",
-            "eRJfCgR0eXBlGCMgAygOMksuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3Bl",
-            "bmFwaXYyLm9wdGlvbnMuSlNPTlNjaGVtYS5KU09OU2NoZW1hU2ltcGxlVHlw",
-            "ZXNSBHR5cGUSFgoGZm9ybWF0GCQgASgJUgZmb3JtYXQSEgoEZW51bRguIAMo",
-            "CVIEZW51bRJ6ChNmaWVsZF9jb25maWd1cmF0aW9uGOkHIAEoCzJILmdycGMu",
-            "Z2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLkpTT05TY2hl",
-            "bWEuRmllbGRDb25maWd1cmF0aW9uUhJmaWVsZENvbmZpZ3VyYXRpb24SZQoK",
-            "ZXh0ZW5zaW9ucxgwIAMoCzJFLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29w",
-            "ZW5hcGl2Mi5vcHRpb25zLkpTT05TY2hlbWEuRXh0ZW5zaW9uc0VudHJ5Ugpl",
-            "eHRlbnNpb25zGjwKEkZpZWxkQ29uZmlndXJhdGlvbhImCg9wYXRoX3BhcmFt",
-            "X25hbWUYLyABKAlSDXBhdGhQYXJhbU5hbWUaVQoPRXh0ZW5zaW9uc0VudHJ5",
-            "EhAKA2tleRgBIAEoCVIDa2V5EiwKBXZhbHVlGAIgASgLMhYuZ29vZ2xlLnBy",
-            "b3RvYnVmLlZhbHVlUgV2YWx1ZToCOAEidwoVSlNPTlNjaGVtYVNpbXBsZVR5",
-            "cGVzEgsKB1VOS05PV04QABIJCgVBUlJBWRABEgsKB0JPT0xFQU4QAhILCgdJ",
-            "TlRFR0VSEAMSCAoETlVMTBAEEgoKBk5VTUJFUhAFEgoKBk9CSkVDVBAGEgoK",
-            "BlNUUklORxAHSgQIARACSgQIAhADSgQIBBAFSgQIEhATSgQIExAUSgQIFxAY",
-            "SgQIGxAcSgQIHBAdSgQIHRAeSgQIHhAiSgQIJRAqSgQIKhArSgQIKxAuIpQB",
-            "CgNUYWcSIAoLZGVzY3JpcHRpb24YAiABKAlSC2Rlc2NyaXB0aW9uEmUKDWV4",
-            "dGVybmFsX2RvY3MYAyABKAsyQC5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9v",
-            "cGVuYXBpdjIub3B0aW9ucy5FeHRlcm5hbERvY3VtZW50YXRpb25SDGV4dGVy",
-            "bmFsRG9jc0oECAEQAiL3AQoTU2VjdXJpdHlEZWZpbml0aW9ucxJoCghzZWN1",
-            "cml0eRgBIAMoCzJMLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2",
-            "Mi5vcHRpb25zLlNlY3VyaXR5RGVmaW5pdGlvbnMuU2VjdXJpdHlFbnRyeVII",
-            "c2VjdXJpdHkadgoNU2VjdXJpdHlFbnRyeRIQCgNrZXkYASABKAlSA2tleRJP",
-            "CgV2YWx1ZRgCIAEoCzI5LmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5h",
-            "cGl2Mi5vcHRpb25zLlNlY3VyaXR5U2NoZW1lUgV2YWx1ZToCOAEi/wYKDlNl",
-            "Y3VyaXR5U2NoZW1lElIKBHR5cGUYASABKA4yPi5ncnBjLmdhdGV3YXkucHJv",
-            "dG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5TZWN1cml0eVNjaGVtZS5UeXBl",
-            "UgR0eXBlEiAKC2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlvbhISCgRu",
-            "YW1lGAMgASgJUgRuYW1lEkwKAmluGAQgASgOMjwuZ3JwYy5nYXRld2F5LnBy",
-            "b3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuU2VjdXJpdHlTY2hlbWUuSW5S",
-            "AmluElIKBGZsb3cYBSABKA4yPi5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9v",
-            "cGVuYXBpdjIub3B0aW9ucy5TZWN1cml0eVNjaGVtZS5GbG93UgRmbG93EisK",
-            "EWF1dGhvcml6YXRpb25fdXJsGAYgASgJUhBhdXRob3JpemF0aW9uVXJsEhsK",
-            "CXRva2VuX3VybBgHIAEoCVIIdG9rZW5VcmwSSQoGc2NvcGVzGAggASgLMjEu",
-            "Z3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuU2Nv",
-            "cGVzUgZzY29wZXMSaQoKZXh0ZW5zaW9ucxgJIAMoCzJJLmdycGMuZ2F0ZXdh",
-            "eS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlNlY3VyaXR5U2NoZW1l",
-            "LkV4dGVuc2lvbnNFbnRyeVIKZXh0ZW5zaW9ucxpVCg9FeHRlbnNpb25zRW50",
-            "cnkSEAoDa2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiABKAsyFi5nb29nbGUu",
-            "cHJvdG9idWYuVmFsdWVSBXZhbHVlOgI4ASJLCgRUeXBlEhAKDFRZUEVfSU5W",
-            "QUxJRBAAEg4KClRZUEVfQkFTSUMQARIQCgxUWVBFX0FQSV9LRVkQAhIPCgtU",
-            "WVBFX09BVVRIMhADIjEKAkluEg4KCklOX0lOVkFMSUQQABIMCghJTl9RVUVS",
-            "WRABEg0KCUlOX0hFQURFUhACImoKBEZsb3cSEAoMRkxPV19JTlZBTElEEAAS",
-            "EQoNRkxPV19JTVBMSUNJVBABEhEKDUZMT1dfUEFTU1dPUkQQAhIUChBGTE9X",
-            "X0FQUExJQ0FUSU9OEAMSFAoQRkxPV19BQ0NFU1NfQ09ERRAEIvYCChNTZWN1",
-            "cml0eVJlcXVpcmVtZW50EooBChRzZWN1cml0eV9yZXF1aXJlbWVudBgBIAMo",
-            "CzJXLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25z",
-            "LlNlY3VyaXR5UmVxdWlyZW1lbnQuU2VjdXJpdHlSZXF1aXJlbWVudEVudHJ5",
-            "UhNzZWN1cml0eVJlcXVpcmVtZW50GjAKGFNlY3VyaXR5UmVxdWlyZW1lbnRW",
-            "YWx1ZRIUCgVzY29wZRgBIAMoCVIFc2NvcGUanwEKGFNlY3VyaXR5UmVxdWly",
-            "ZW1lbnRFbnRyeRIQCgNrZXkYASABKAlSA2tleRJtCgV2YWx1ZRgCIAEoCzJX",
-            "LmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlNl",
-            "Y3VyaXR5UmVxdWlyZW1lbnQuU2VjdXJpdHlSZXF1aXJlbWVudFZhbHVlUgV2",
-            "YWx1ZToCOAEilgEKBlNjb3BlcxJSCgVzY29wZRgBIAMoCzI8LmdycGMuZ2F0",
-            "ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlNjb3Blcy5TY29w",
-            "ZUVudHJ5UgVzY29wZRo4CgpTY29wZUVudHJ5EhAKA2tleRgBIAEoCVIDa2V5",
-            "EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEqOwoGU2NoZW1lEgsKB1VOS05P",
-            "V04QABIICgRIVFRQEAESCQoFSFRUUFMQAhIGCgJXUxADEgcKA1dTUxAEQkha",
-            "RmdpdGh1Yi5jb20vZ3JwYy1lY29zeXN0ZW0vZ3JwYy1nYXRld2F5L3YyL3By",
-            "b3RvYy1nZW4tb3BlbmFwaXYyL29wdGlvbnNiBnByb3RvMw=="));
+            "b3B0aW9ucy5TZWN1cml0eVJlcXVpcmVtZW50UghzZWN1cml0eRJCCgR0YWdz",
+            "GA0gAygLMi4uZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9w",
+            "dGlvbnMuVGFnUgR0YWdzEmUKDWV4dGVybmFsX2RvY3MYDiABKAsyQC5ncnBj",
+            "LmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5FeHRlcm5h",
+            "bERvY3VtZW50YXRpb25SDGV4dGVybmFsRG9jcxJiCgpleHRlbnNpb25zGA8g",
+            "AygLMkIuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlv",
+            "bnMuU3dhZ2dlci5FeHRlbnNpb25zRW50cnlSCmV4dGVuc2lvbnMacQoOUmVz",
+            "cG9uc2VzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSSQoFdmFsdWUYAiABKAsy",
+            "My5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5S",
+            "ZXNwb25zZVIFdmFsdWU6AjgBGlUKD0V4dGVuc2lvbnNFbnRyeRIQCgNrZXkY",
+            "ASABKAlSA2tleRIsCgV2YWx1ZRgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5W",
+            "YWx1ZVIFdmFsdWU6AjgBSgQICBAJSgQICRAKItYHCglPcGVyYXRpb24SEgoE",
+            "dGFncxgBIAMoCVIEdGFncxIYCgdzdW1tYXJ5GAIgASgJUgdzdW1tYXJ5EiAK",
+            "C2Rlc2NyaXB0aW9uGAMgASgJUgtkZXNjcmlwdGlvbhJlCg1leHRlcm5hbF9k",
+            "b2NzGAQgASgLMkAuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYy",
+            "Lm9wdGlvbnMuRXh0ZXJuYWxEb2N1bWVudGF0aW9uUgxleHRlcm5hbERvY3MS",
+            "IQoMb3BlcmF0aW9uX2lkGAUgASgJUgtvcGVyYXRpb25JZBIaCghjb25zdW1l",
+            "cxgGIAMoCVIIY29uc3VtZXMSGgoIcHJvZHVjZXMYByADKAlSCHByb2R1Y2Vz",
+            "EmEKCXJlc3BvbnNlcxgJIAMoCzJDLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2Vu",
+            "X29wZW5hcGl2Mi5vcHRpb25zLk9wZXJhdGlvbi5SZXNwb25zZXNFbnRyeVIJ",
+            "cmVzcG9uc2VzEksKB3NjaGVtZXMYCiADKA4yMS5ncnBjLmdhdGV3YXkucHJv",
+            "dG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5TY2hlbWVSB3NjaGVtZXMSHgoK",
+            "ZGVwcmVjYXRlZBgLIAEoCFIKZGVwcmVjYXRlZBJaCghzZWN1cml0eRgMIAMo",
+            "CzI+LmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25z",
+            "LlNlY3VyaXR5UmVxdWlyZW1lbnRSCHNlY3VyaXR5EmQKCmV4dGVuc2lvbnMY",
+            "DSADKAsyRC5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0",
+            "aW9ucy5PcGVyYXRpb24uRXh0ZW5zaW9uc0VudHJ5UgpleHRlbnNpb25zElUK",
+            "CnBhcmFtZXRlcnMYDiABKAsyNS5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9v",
+            "cGVuYXBpdjIub3B0aW9ucy5QYXJhbWV0ZXJzUgpwYXJhbWV0ZXJzGnEKDlJl",
+            "c3BvbnNlc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EkkKBXZhbHVlGAIgASgL",
+            "MjMuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMu",
+            "UmVzcG9uc2VSBXZhbHVlOgI4ARpVCg9FeHRlbnNpb25zRW50cnkSEAoDa2V5",
+            "GAEgASgJUgNrZXkSLAoFdmFsdWUYAiABKAsyFi5nb29nbGUucHJvdG9idWYu",
+            "VmFsdWVSBXZhbHVlOgI4AUoECAgQCSJiCgpQYXJhbWV0ZXJzElQKB2hlYWRl",
+            "cnMYASADKAsyOi5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIu",
+            "b3B0aW9ucy5IZWFkZXJQYXJhbWV0ZXJSB2hlYWRlcnMiowIKD0hlYWRlclBh",
+            "cmFtZXRlchISCgRuYW1lGAEgASgJUgRuYW1lEiAKC2Rlc2NyaXB0aW9uGAIg",
+            "ASgJUgtkZXNjcmlwdGlvbhJTCgR0eXBlGAMgASgOMj8uZ3JwYy5nYXRld2F5",
+            "LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuSGVhZGVyUGFyYW1ldGVy",
+            "LlR5cGVSBHR5cGUSFgoGZm9ybWF0GAQgASgJUgZmb3JtYXQSGgoIcmVxdWly",
+            "ZWQYBSABKAhSCHJlcXVpcmVkIkUKBFR5cGUSCwoHVU5LTk9XThAAEgoKBlNU",
+            "UklORxABEgoKBk5VTUJFUhACEgsKB0lOVEVHRVIQAxILCgdCT09MRUFOEARK",
+            "BAgGEAdKBAgHEAgi2AEKBkhlYWRlchIgCgtkZXNjcmlwdGlvbhgBIAEoCVIL",
+            "ZGVzY3JpcHRpb24SEgoEdHlwZRgCIAEoCVIEdHlwZRIWCgZmb3JtYXQYAyAB",
+            "KAlSBmZvcm1hdBIYCgdkZWZhdWx0GAYgASgJUgdkZWZhdWx0EhgKB3BhdHRl",
+            "cm4YDSABKAlSB3BhdHRlcm5KBAgEEAVKBAgFEAZKBAgHEAhKBAgIEAlKBAgJ",
+            "EApKBAgKEAtKBAgLEAxKBAgMEA1KBAgOEA9KBAgPEBBKBAgQEBFKBAgREBJK",
+            "BAgSEBMimgUKCFJlc3BvbnNlEiAKC2Rlc2NyaXB0aW9uGAEgASgJUgtkZXNj",
+            "cmlwdGlvbhJJCgZzY2hlbWEYAiABKAsyMS5ncnBjLmdhdGV3YXkucHJvdG9j",
+            "X2dlbl9vcGVuYXBpdjIub3B0aW9ucy5TY2hlbWFSBnNjaGVtYRJaCgdoZWFk",
+            "ZXJzGAMgAygLMkAuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYy",
+            "Lm9wdGlvbnMuUmVzcG9uc2UuSGVhZGVyc0VudHJ5UgdoZWFkZXJzEl0KCGV4",
+            "YW1wbGVzGAQgAygLMkEuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFw",
+            "aXYyLm9wdGlvbnMuUmVzcG9uc2UuRXhhbXBsZXNFbnRyeVIIZXhhbXBsZXMS",
+            "YwoKZXh0ZW5zaW9ucxgFIAMoCzJDLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2Vu",
+            "X29wZW5hcGl2Mi5vcHRpb25zLlJlc3BvbnNlLkV4dGVuc2lvbnNFbnRyeVIK",
+            "ZXh0ZW5zaW9ucxptCgxIZWFkZXJzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkS",
+            "RwoFdmFsdWUYAiABKAsyMS5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVu",
+            "YXBpdjIub3B0aW9ucy5IZWFkZXJSBXZhbHVlOgI4ARo7Cg1FeGFtcGxlc0Vu",
+            "dHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToC",
+            "OAEaVQoPRXh0ZW5zaW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EiwKBXZh",
+            "bHVlGAIgASgLMhYuZ29vZ2xlLnByb3RvYnVmLlZhbHVlUgV2YWx1ZToCOAEi",
+            "1gMKBEluZm8SFAoFdGl0bGUYASABKAlSBXRpdGxlEiAKC2Rlc2NyaXB0aW9u",
+            "GAIgASgJUgtkZXNjcmlwdGlvbhIoChB0ZXJtc19vZl9zZXJ2aWNlGAMgASgJ",
+            "Ug50ZXJtc09mU2VydmljZRJMCgdjb250YWN0GAQgASgLMjIuZ3JwYy5nYXRl",
+            "d2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuQ29udGFjdFIHY29u",
+            "dGFjdBJMCgdsaWNlbnNlGAUgASgLMjIuZ3JwYy5nYXRld2F5LnByb3RvY19n",
+            "ZW5fb3BlbmFwaXYyLm9wdGlvbnMuTGljZW5zZVIHbGljZW5zZRIYCgd2ZXJz",
+            "aW9uGAYgASgJUgd2ZXJzaW9uEl8KCmV4dGVuc2lvbnMYByADKAsyPy5ncnBj",
+            "LmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5JbmZvLkV4",
+            "dGVuc2lvbnNFbnRyeVIKZXh0ZW5zaW9ucxpVCg9FeHRlbnNpb25zRW50cnkS",
+            "EAoDa2V5GAEgASgJUgNrZXkSLAoFdmFsdWUYAiABKAsyFi5nb29nbGUucHJv",
+            "dG9idWYuVmFsdWVSBXZhbHVlOgI4ASJFCgdDb250YWN0EhIKBG5hbWUYASAB",
+            "KAlSBG5hbWUSEAoDdXJsGAIgASgJUgN1cmwSFAoFZW1haWwYAyABKAlSBWVt",
+            "YWlsIi8KB0xpY2Vuc2USEgoEbmFtZRgBIAEoCVIEbmFtZRIQCgN1cmwYAiAB",
+            "KAlSA3VybCJLChVFeHRlcm5hbERvY3VtZW50YXRpb24SIAoLZGVzY3JpcHRp",
+            "b24YASABKAlSC2Rlc2NyaXB0aW9uEhAKA3VybBgCIAEoCVIDdXJsIqoCCgZT",
+            "Y2hlbWESVgoLanNvbl9zY2hlbWEYASABKAsyNS5ncnBjLmdhdGV3YXkucHJv",
+            "dG9jX2dlbl9vcGVuYXBpdjIub3B0aW9ucy5KU09OU2NoZW1hUgpqc29uU2No",
+            "ZW1hEiQKDWRpc2NyaW1pbmF0b3IYAiABKAlSDWRpc2NyaW1pbmF0b3ISGwoJ",
+            "cmVhZF9vbmx5GAMgASgIUghyZWFkT25seRJlCg1leHRlcm5hbF9kb2NzGAUg",
+            "ASgLMkAuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlv",
+            "bnMuRXh0ZXJuYWxEb2N1bWVudGF0aW9uUgxleHRlcm5hbERvY3MSGAoHZXhh",
+            "bXBsZRgGIAEoCVIHZXhhbXBsZUoECAQQBSLXCgoKSlNPTlNjaGVtYRIQCgNy",
+            "ZWYYAyABKAlSA3JlZhIUCgV0aXRsZRgFIAEoCVIFdGl0bGUSIAoLZGVzY3Jp",
+            "cHRpb24YBiABKAlSC2Rlc2NyaXB0aW9uEhgKB2RlZmF1bHQYByABKAlSB2Rl",
+            "ZmF1bHQSGwoJcmVhZF9vbmx5GAggASgIUghyZWFkT25seRIYCgdleGFtcGxl",
+            "GAkgASgJUgdleGFtcGxlEh8KC211bHRpcGxlX29mGAogASgBUgptdWx0aXBs",
+            "ZU9mEhgKB21heGltdW0YCyABKAFSB21heGltdW0SKwoRZXhjbHVzaXZlX21h",
+            "eGltdW0YDCABKAhSEGV4Y2x1c2l2ZU1heGltdW0SGAoHbWluaW11bRgNIAEo",
+            "AVIHbWluaW11bRIrChFleGNsdXNpdmVfbWluaW11bRgOIAEoCFIQZXhjbHVz",
+            "aXZlTWluaW11bRIdCgptYXhfbGVuZ3RoGA8gASgEUgltYXhMZW5ndGgSHQoK",
+            "bWluX2xlbmd0aBgQIAEoBFIJbWluTGVuZ3RoEhgKB3BhdHRlcm4YESABKAlS",
+            "B3BhdHRlcm4SGwoJbWF4X2l0ZW1zGBQgASgEUghtYXhJdGVtcxIbCgltaW5f",
+            "aXRlbXMYFSABKARSCG1pbkl0ZW1zEiEKDHVuaXF1ZV9pdGVtcxgWIAEoCFIL",
+            "dW5pcXVlSXRlbXMSJQoObWF4X3Byb3BlcnRpZXMYGCABKARSDW1heFByb3Bl",
+            "cnRpZXMSJQoObWluX3Byb3BlcnRpZXMYGSABKARSDW1pblByb3BlcnRpZXMS",
+            "GgoIcmVxdWlyZWQYGiADKAlSCHJlcXVpcmVkEhQKBWFycmF5GCIgAygJUgVh",
+            "cnJheRJfCgR0eXBlGCMgAygOMksuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5f",
+            "b3BlbmFwaXYyLm9wdGlvbnMuSlNPTlNjaGVtYS5KU09OU2NoZW1hU2ltcGxl",
+            "VHlwZXNSBHR5cGUSFgoGZm9ybWF0GCQgASgJUgZmb3JtYXQSEgoEZW51bRgu",
+            "IAMoCVIEZW51bRJ6ChNmaWVsZF9jb25maWd1cmF0aW9uGOkHIAEoCzJILmdy",
+            "cGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLkpTT05T",
+            "Y2hlbWEuRmllbGRDb25maWd1cmF0aW9uUhJmaWVsZENvbmZpZ3VyYXRpb24S",
+            "ZQoKZXh0ZW5zaW9ucxgwIAMoCzJFLmdycGMuZ2F0ZXdheS5wcm90b2NfZ2Vu",
+            "X29wZW5hcGl2Mi5vcHRpb25zLkpTT05TY2hlbWEuRXh0ZW5zaW9uc0VudHJ5",
+            "UgpleHRlbnNpb25zGjwKEkZpZWxkQ29uZmlndXJhdGlvbhImCg9wYXRoX3Bh",
+            "cmFtX25hbWUYLyABKAlSDXBhdGhQYXJhbU5hbWUaVQoPRXh0ZW5zaW9uc0Vu",
+            "dHJ5EhAKA2tleRgBIAEoCVIDa2V5EiwKBXZhbHVlGAIgASgLMhYuZ29vZ2xl",
+            "LnByb3RvYnVmLlZhbHVlUgV2YWx1ZToCOAEidwoVSlNPTlNjaGVtYVNpbXBs",
+            "ZVR5cGVzEgsKB1VOS05PV04QABIJCgVBUlJBWRABEgsKB0JPT0xFQU4QAhIL",
+            "CgdJTlRFR0VSEAMSCAoETlVMTBAEEgoKBk5VTUJFUhAFEgoKBk9CSkVDVBAG",
+            "EgoKBlNUUklORxAHSgQIARACSgQIAhADSgQIBBAFSgQIEhATSgQIExAUSgQI",
+            "FxAYSgQIGxAcSgQIHBAdSgQIHRAeSgQIHhAiSgQIJRAqSgQIKhArSgQIKxAu",
+            "ItkCCgNUYWcSEgoEbmFtZRgBIAEoCVIEbmFtZRIgCgtkZXNjcmlwdGlvbhgC",
+            "IAEoCVILZGVzY3JpcHRpb24SZQoNZXh0ZXJuYWxfZG9jcxgDIAEoCzJALmdy",
+            "cGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLkV4dGVy",
+            "bmFsRG9jdW1lbnRhdGlvblIMZXh0ZXJuYWxEb2NzEl4KCmV4dGVuc2lvbnMY",
+            "BCADKAsyPi5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0",
+            "aW9ucy5UYWcuRXh0ZW5zaW9uc0VudHJ5UgpleHRlbnNpb25zGlUKD0V4dGVu",
+            "c2lvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIsCgV2YWx1ZRgCIAEoCzIW",
+            "Lmdvb2dsZS5wcm90b2J1Zi5WYWx1ZVIFdmFsdWU6AjgBIvcBChNTZWN1cml0",
+            "eURlZmluaXRpb25zEmgKCHNlY3VyaXR5GAEgAygLMkwuZ3JwYy5nYXRld2F5",
+            "LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuU2VjdXJpdHlEZWZpbml0",
+            "aW9ucy5TZWN1cml0eUVudHJ5UghzZWN1cml0eRp2Cg1TZWN1cml0eUVudHJ5",
+            "EhAKA2tleRgBIAEoCVIDa2V5Ek8KBXZhbHVlGAIgASgLMjkuZ3JwYy5nYXRl",
+            "d2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9wdGlvbnMuU2VjdXJpdHlTY2hl",
+            "bWVSBXZhbHVlOgI4ASL/BgoOU2VjdXJpdHlTY2hlbWUSUgoEdHlwZRgBIAEo",
+            "DjI+LmdycGMuZ2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25z",
+            "LlNlY3VyaXR5U2NoZW1lLlR5cGVSBHR5cGUSIAoLZGVzY3JpcHRpb24YAiAB",
+            "KAlSC2Rlc2NyaXB0aW9uEhIKBG5hbWUYAyABKAlSBG5hbWUSTAoCaW4YBCAB",
+            "KA4yPC5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9vcGVuYXBpdjIub3B0aW9u",
+            "cy5TZWN1cml0eVNjaGVtZS5JblICaW4SUgoEZmxvdxgFIAEoDjI+LmdycGMu",
+            "Z2F0ZXdheS5wcm90b2NfZ2VuX29wZW5hcGl2Mi5vcHRpb25zLlNlY3VyaXR5",
+            "U2NoZW1lLkZsb3dSBGZsb3cSKwoRYXV0aG9yaXphdGlvbl91cmwYBiABKAlS",
+            "EGF1dGhvcml6YXRpb25VcmwSGwoJdG9rZW5fdXJsGAcgASgJUgh0b2tlblVy",
+            "bBJJCgZzY29wZXMYCCABKAsyMS5ncnBjLmdhdGV3YXkucHJvdG9jX2dlbl9v",
+            "cGVuYXBpdjIub3B0aW9ucy5TY29wZXNSBnNjb3BlcxJpCgpleHRlbnNpb25z",
+            "GAkgAygLMkkuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYyLm9w",
+            "dGlvbnMuU2VjdXJpdHlTY2hlbWUuRXh0ZW5zaW9uc0VudHJ5UgpleHRlbnNp",
+            "b25zGlUKD0V4dGVuc2lvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIsCgV2",
+            "YWx1ZRgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZVIFdmFsdWU6AjgB",
+            "IksKBFR5cGUSEAoMVFlQRV9JTlZBTElEEAASDgoKVFlQRV9CQVNJQxABEhAK",
+            "DFRZUEVfQVBJX0tFWRACEg8KC1RZUEVfT0FVVEgyEAMiMQoCSW4SDgoKSU5f",
+            "SU5WQUxJRBAAEgwKCElOX1FVRVJZEAESDQoJSU5fSEVBREVSEAIiagoERmxv",
+            "dxIQCgxGTE9XX0lOVkFMSUQQABIRCg1GTE9XX0lNUExJQ0lUEAESEQoNRkxP",
+            "V19QQVNTV09SRBACEhQKEEZMT1dfQVBQTElDQVRJT04QAxIUChBGTE9XX0FD",
+            "Q0VTU19DT0RFEAQi9gIKE1NlY3VyaXR5UmVxdWlyZW1lbnQSigEKFHNlY3Vy",
+            "aXR5X3JlcXVpcmVtZW50GAEgAygLMlcuZ3JwYy5nYXRld2F5LnByb3RvY19n",
+            "ZW5fb3BlbmFwaXYyLm9wdGlvbnMuU2VjdXJpdHlSZXF1aXJlbWVudC5TZWN1",
+            "cml0eVJlcXVpcmVtZW50RW50cnlSE3NlY3VyaXR5UmVxdWlyZW1lbnQaMAoY",
+            "U2VjdXJpdHlSZXF1aXJlbWVudFZhbHVlEhQKBXNjb3BlGAEgAygJUgVzY29w",
+            "ZRqfAQoYU2VjdXJpdHlSZXF1aXJlbWVudEVudHJ5EhAKA2tleRgBIAEoCVID",
+            "a2V5Em0KBXZhbHVlGAIgASgLMlcuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5f",
+            "b3BlbmFwaXYyLm9wdGlvbnMuU2VjdXJpdHlSZXF1aXJlbWVudC5TZWN1cml0",
+            "eVJlcXVpcmVtZW50VmFsdWVSBXZhbHVlOgI4ASKWAQoGU2NvcGVzElIKBXNj",
+            "b3BlGAEgAygLMjwuZ3JwYy5nYXRld2F5LnByb3RvY19nZW5fb3BlbmFwaXYy",
+            "Lm9wdGlvbnMuU2NvcGVzLlNjb3BlRW50cnlSBXNjb3BlGjgKClNjb3BlRW50",
+            "cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4",
+            "ASo7CgZTY2hlbWUSCwoHVU5LTk9XThAAEggKBEhUVFAQARIJCgVIVFRQUxAC",
+            "EgYKAldTEAMSBwoDV1NTEARCSFpGZ2l0aHViLmNvbS9ncnBjLWVjb3N5c3Rl",
+            "bS9ncnBjLWdhdGV3YXkvdjIvcHJvdG9jLWdlbi1vcGVuYXBpdjIvb3B0aW9u",
+            "c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Scheme), }, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Swagger), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Swagger.Parser, new[]{ "Swagger_", "Info", "Host", "BasePath", "Schemes", "Consumes", "Produces", "Responses", "SecurityDefinitions", "Security", "ExternalDocs", "Extensions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Operation), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Operation.Parser, new[]{ "Tags", "Summary", "Description", "ExternalDocs", "OperationId", "Consumes", "Produces", "Responses", "Schemes", "Deprecated", "Security", "Extensions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Swagger), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Swagger.Parser, new[]{ "Swagger_", "Info", "Host", "BasePath", "Schemes", "Consumes", "Produces", "Responses", "SecurityDefinitions", "Security", "Tags", "ExternalDocs", "Extensions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Operation), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Operation.Parser, new[]{ "Tags", "Summary", "Description", "ExternalDocs", "OperationId", "Consumes", "Produces", "Responses", "Schemes", "Deprecated", "Security", "Extensions", "Parameters" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters.Parser, new[]{ "Headers" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Parser, new[]{ "Name", "Description", "Type", "Format", "Required" }, null, new[]{ typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type) }, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Header), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Header.Parser, new[]{ "Description", "Type", "Format", "Default", "Pattern" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Response), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Response.Parser, new[]{ "Description", "Schema", "Headers", "Examples", "Extensions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Info), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Info.Parser, new[]{ "Title", "Description", "TermsOfService", "Contact", "License", "Version", "Extensions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
@@ -199,7 +218,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Schema), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Schema.Parser, new[]{ "JsonSchema", "Discriminator", "ReadOnly", "ExternalDocs", "Example" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.JSONSchema), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.JSONSchema.Parser, new[]{ "Ref", "Title", "Description", "Default", "ReadOnly", "Example", "MultipleOf", "Maximum", "ExclusiveMaximum", "Minimum", "ExclusiveMinimum", "MaxLength", "MinLength", "Pattern", "MaxItems", "MinItems", "UniqueItems", "MaxProperties", "MinProperties", "Required", "Array", "Type", "Format", "Enum", "FieldConfiguration", "Extensions" }, null, new[]{ typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.JSONSchema.Types.JSONSchemaSimpleTypes) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.JSONSchema.Types.FieldConfiguration), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.JSONSchema.Types.FieldConfiguration.Parser, new[]{ "PathParamName" }, null, null, null, null),
             null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag.Parser, new[]{ "Description", "ExternalDocs" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag.Parser, new[]{ "Name", "Description", "ExternalDocs", "Extensions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityDefinitions), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityDefinitions.Parser, new[]{ "Security" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityScheme), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityScheme.Parser, new[]{ "Type", "Description", "Name", "In", "Flow", "AuthorizationUrl", "TokenUrl", "Scopes", "Extensions" }, null, new[]{ typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityScheme.Types.Type), typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityScheme.Types.In), typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityScheme.Types.Flow) }, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityRequirement), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityRequirement.Parser, new[]{ "SecurityRequirement_" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityRequirement.Types.SecurityRequirementValue), global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityRequirement.Types.SecurityRequirementValue.Parser, new[]{ "Scope" }, null, null, null, null),
@@ -245,7 +264,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///      };
   ///      license: {
   ///        name: "BSD 3-Clause License";
-  ///        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+  ///        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
   ///      };
   ///    };
   ///    schemes: HTTPS;
@@ -297,6 +316,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       responses_ = other.responses_.Clone();
       securityDefinitions_ = other.securityDefinitions_ != null ? other.securityDefinitions_.Clone() : null;
       security_ = other.security_.Clone();
+      tags_ = other.tags_.Clone();
       externalDocs_ = other.externalDocs_ != null ? other.externalDocs_.Clone() : null;
       extensions_ = other.extensions_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -477,6 +497,21 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       get { return security_; }
     }
 
+    /// <summary>Field number for the "tags" field.</summary>
+    public const int TagsFieldNumber = 13;
+    private static readonly pb::FieldCodec<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag> _repeated_tags_codec
+        = pb::FieldCodec.ForMessage(106, global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag.Parser);
+    private readonly pbc::RepeatedField<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag> tags_ = new pbc::RepeatedField<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag>();
+    /// <summary>
+    /// A list of tags for API documentation control. Tags can be used for logical
+    /// grouping of operations by resources or any other qualifier.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::RepeatedField<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Tag> Tags {
+      get { return tags_; }
+    }
+
     /// <summary>Field number for the "external_docs" field.</summary>
     public const int ExternalDocsFieldNumber = 14;
     private global::Grpc.Gateway.ProtocGenOpenapiv2.Options.ExternalDocumentation externalDocs_;
@@ -497,6 +532,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
         = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 122);
     private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
@@ -528,6 +568,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (!Responses.Equals(other.Responses)) return false;
       if (!object.Equals(SecurityDefinitions, other.SecurityDefinitions)) return false;
       if(!security_.Equals(other.security_)) return false;
+      if(!tags_.Equals(other.tags_)) return false;
       if (!object.Equals(ExternalDocs, other.ExternalDocs)) return false;
       if (!Extensions.Equals(other.Extensions)) return false;
       return Equals(_unknownFields, other._unknownFields);
@@ -547,6 +588,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       hash ^= Responses.GetHashCode();
       if (securityDefinitions_ != null) hash ^= SecurityDefinitions.GetHashCode();
       hash ^= security_.GetHashCode();
+      hash ^= tags_.GetHashCode();
       if (externalDocs_ != null) hash ^= ExternalDocs.GetHashCode();
       hash ^= Extensions.GetHashCode();
       if (_unknownFields != null) {
@@ -592,6 +634,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         output.WriteMessage(SecurityDefinitions);
       }
       security_.WriteTo(output, _repeated_security_codec);
+      tags_.WriteTo(output, _repeated_tags_codec);
       if (externalDocs_ != null) {
         output.WriteRawTag(114);
         output.WriteMessage(ExternalDocs);
@@ -632,6 +675,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         output.WriteMessage(SecurityDefinitions);
       }
       security_.WriteTo(ref output, _repeated_security_codec);
+      tags_.WriteTo(ref output, _repeated_tags_codec);
       if (externalDocs_ != null) {
         output.WriteRawTag(114);
         output.WriteMessage(ExternalDocs);
@@ -667,6 +711,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SecurityDefinitions);
       }
       size += security_.CalculateSize(_repeated_security_codec);
+      size += tags_.CalculateSize(_repeated_tags_codec);
       if (externalDocs_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ExternalDocs);
       }
@@ -701,7 +746,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       schemes_.Add(other.schemes_);
       consumes_.Add(other.consumes_);
       produces_.Add(other.produces_);
-      responses_.Add(other.responses_);
+      responses_.MergeFrom(other.responses_);
       if (other.securityDefinitions_ != null) {
         if (securityDefinitions_ == null) {
           SecurityDefinitions = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityDefinitions();
@@ -709,13 +754,14 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         SecurityDefinitions.MergeFrom(other.SecurityDefinitions);
       }
       security_.Add(other.security_);
+      tags_.Add(other.tags_);
       if (other.externalDocs_ != null) {
         if (externalDocs_ == null) {
           ExternalDocs = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.ExternalDocumentation();
         }
         ExternalDocs.MergeFrom(other.ExternalDocs);
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -776,6 +822,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
           }
           case 98: {
             security_.AddEntriesFrom(input, _repeated_security_codec);
+            break;
+          }
+          case 106: {
+            tags_.AddEntriesFrom(input, _repeated_tags_codec);
             break;
           }
           case 114: {
@@ -849,6 +899,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
           }
           case 98: {
             security_.AddEntriesFrom(ref input, _repeated_security_codec);
+            break;
+          }
+          case 106: {
+            tags_.AddEntriesFrom(ref input, _repeated_tags_codec);
             break;
           }
           case 114: {
@@ -942,6 +996,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       deprecated_ = other.deprecated_;
       security_ = other.security_.Clone();
       extensions_ = other.extensions_.Clone();
+      parameters_ = other.parameters_ != null ? other.parameters_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -1133,10 +1188,32 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
         = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 106);
     private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
       get { return extensions_; }
+    }
+
+    /// <summary>Field number for the "parameters" field.</summary>
+    public const int ParametersFieldNumber = 14;
+    private global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters parameters_;
+    /// <summary>
+    /// Custom parameters such as HTTP request headers.
+    /// See: https://swagger.io/docs/specification/2-0/describing-parameters/
+    /// and https://swagger.io/specification/v2/#parameter-object.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters Parameters {
+      get { return parameters_; }
+      set {
+        parameters_ = value;
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1166,6 +1243,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (Deprecated != other.Deprecated) return false;
       if(!security_.Equals(other.security_)) return false;
       if (!Extensions.Equals(other.Extensions)) return false;
+      if (!object.Equals(Parameters, other.Parameters)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1185,6 +1263,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (Deprecated != false) hash ^= Deprecated.GetHashCode();
       hash ^= security_.GetHashCode();
       hash ^= Extensions.GetHashCode();
+      if (parameters_ != null) hash ^= Parameters.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1230,6 +1309,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       }
       security_.WriteTo(output, _repeated_security_codec);
       extensions_.WriteTo(output, _map_extensions_codec);
+      if (parameters_ != null) {
+        output.WriteRawTag(114);
+        output.WriteMessage(Parameters);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1267,6 +1350,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       }
       security_.WriteTo(ref output, _repeated_security_codec);
       extensions_.WriteTo(ref output, _map_extensions_codec);
+      if (parameters_ != null) {
+        output.WriteRawTag(114);
+        output.WriteMessage(Parameters);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1299,6 +1386,9 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       }
       size += security_.CalculateSize(_repeated_security_codec);
       size += extensions_.CalculateSize(_map_extensions_codec);
+      if (parameters_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Parameters);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -1329,13 +1419,19 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       }
       consumes_.Add(other.consumes_);
       produces_.Add(other.produces_);
-      responses_.Add(other.responses_);
+      responses_.MergeFrom(other.responses_);
       schemes_.Add(other.schemes_);
       if (other.Deprecated != false) {
         Deprecated = other.Deprecated;
       }
       security_.Add(other.security_);
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
+      if (other.parameters_ != null) {
+        if (parameters_ == null) {
+          Parameters = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters();
+        }
+        Parameters.MergeFrom(other.Parameters);
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -1401,6 +1497,13 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
           }
           case 106: {
             extensions_.AddEntriesFrom(input, _map_extensions_codec);
+            break;
+          }
+          case 114: {
+            if (parameters_ == null) {
+              Parameters = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters();
+            }
+            input.ReadMessage(Parameters);
             break;
           }
         }
@@ -1470,10 +1573,583 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
             extensions_.AddEntriesFrom(ref input, _map_extensions_codec);
             break;
           }
+          case 114: {
+            if (parameters_ == null) {
+              Parameters = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Parameters();
+            }
+            input.ReadMessage(Parameters);
+            break;
+          }
         }
       }
     }
     #endif
+
+  }
+
+  /// <summary>
+  /// `Parameters` is a representation of OpenAPI v2 specification's parameters object.
+  /// Note: This technically breaks compatibility with the OpenAPI 2 definition structure as we only
+  /// allow header parameters to be set here since we do not want users specifying custom non-header
+  /// parameters beyond those inferred from the Protobuf schema.
+  /// See: https://swagger.io/specification/v2/#parameter-object
+  /// </summary>
+  public sealed partial class Parameters : pb::IMessage<Parameters>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<Parameters> _parser = new pb::MessageParser<Parameters>(() => new Parameters());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<Parameters> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[2]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Parameters() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Parameters(Parameters other) : this() {
+      headers_ = other.headers_.Clone();
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Parameters Clone() {
+      return new Parameters(this);
+    }
+
+    /// <summary>Field number for the "headers" field.</summary>
+    public const int HeadersFieldNumber = 1;
+    private static readonly pb::FieldCodec<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter> _repeated_headers_codec
+        = pb::FieldCodec.ForMessage(10, global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Parser);
+    private readonly pbc::RepeatedField<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter> headers_ = new pbc::RepeatedField<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter>();
+    /// <summary>
+    /// `Headers` is one or more HTTP header parameter.
+    /// See: https://swagger.io/docs/specification/2-0/describing-parameters/#header-parameters
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::RepeatedField<global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter> Headers {
+      get { return headers_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as Parameters);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(Parameters other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if(!headers_.Equals(other.headers_)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      hash ^= headers_.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      headers_.WriteTo(output, _repeated_headers_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      headers_.WriteTo(ref output, _repeated_headers_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      size += headers_.CalculateSize(_repeated_headers_codec);
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(Parameters other) {
+      if (other == null) {
+        return;
+      }
+      headers_.Add(other.headers_);
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            headers_.AddEntriesFrom(input, _repeated_headers_codec);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            headers_.AddEntriesFrom(ref input, _repeated_headers_codec);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// `HeaderParameter` a HTTP header parameter.
+  /// See: https://swagger.io/specification/v2/#parameter-object
+  /// </summary>
+  public sealed partial class HeaderParameter : pb::IMessage<HeaderParameter>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<HeaderParameter> _parser = new pb::MessageParser<HeaderParameter>(() => new HeaderParameter());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<HeaderParameter> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[3]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public HeaderParameter() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public HeaderParameter(HeaderParameter other) : this() {
+      name_ = other.name_;
+      description_ = other.description_;
+      type_ = other.type_;
+      format_ = other.format_;
+      required_ = other.required_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public HeaderParameter Clone() {
+      return new HeaderParameter(this);
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 1;
+    private string name_ = "";
+    /// <summary>
+    /// `Name` is the header name.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "description" field.</summary>
+    public const int DescriptionFieldNumber = 2;
+    private string description_ = "";
+    /// <summary>
+    /// `Description` is a short description of the header.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Description {
+      get { return description_; }
+      set {
+        description_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "type" field.</summary>
+    public const int TypeFieldNumber = 3;
+    private global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type type_ = global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type.Unknown;
+    /// <summary>
+    /// `Type` is the type of the object. The value MUST be one of "string", "number", "integer", or "boolean". The "array" type is not supported.
+    /// See: https://swagger.io/specification/v2/#parameterType.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type Type {
+      get { return type_; }
+      set {
+        type_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "format" field.</summary>
+    public const int FormatFieldNumber = 4;
+    private string format_ = "";
+    /// <summary>
+    /// `Format` The extending format for the previously mentioned type.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Format {
+      get { return format_; }
+      set {
+        format_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "required" field.</summary>
+    public const int RequiredFieldNumber = 5;
+    private bool required_;
+    /// <summary>
+    /// `Required` indicates if the header is optional
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Required {
+      get { return required_; }
+      set {
+        required_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as HeaderParameter);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(HeaderParameter other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Name != other.Name) return false;
+      if (Description != other.Description) return false;
+      if (Type != other.Type) return false;
+      if (Format != other.Format) return false;
+      if (Required != other.Required) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (Description.Length != 0) hash ^= Description.GetHashCode();
+      if (Type != global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type.Unknown) hash ^= Type.GetHashCode();
+      if (Format.Length != 0) hash ^= Format.GetHashCode();
+      if (Required != false) hash ^= Required.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
+      if (Description.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Description);
+      }
+      if (Type != global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type.Unknown) {
+        output.WriteRawTag(24);
+        output.WriteEnum((int) Type);
+      }
+      if (Format.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(Format);
+      }
+      if (Required != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(Required);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
+      if (Description.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Description);
+      }
+      if (Type != global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type.Unknown) {
+        output.WriteRawTag(24);
+        output.WriteEnum((int) Type);
+      }
+      if (Format.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(Format);
+      }
+      if (Required != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(Required);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (Description.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Description);
+      }
+      if (Type != global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type.Unknown) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Type);
+      }
+      if (Format.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Format);
+      }
+      if (Required != false) {
+        size += 1 + 1;
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(HeaderParameter other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      if (other.Description.Length != 0) {
+        Description = other.Description;
+      }
+      if (other.Type != global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type.Unknown) {
+        Type = other.Type;
+      }
+      if (other.Format.Length != 0) {
+        Format = other.Format;
+      }
+      if (other.Required != false) {
+        Required = other.Required;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
+          case 18: {
+            Description = input.ReadString();
+            break;
+          }
+          case 24: {
+            Type = (global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type) input.ReadEnum();
+            break;
+          }
+          case 34: {
+            Format = input.ReadString();
+            break;
+          }
+          case 40: {
+            Required = input.ReadBool();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
+          case 18: {
+            Description = input.ReadString();
+            break;
+          }
+          case 24: {
+            Type = (global::Grpc.Gateway.ProtocGenOpenapiv2.Options.HeaderParameter.Types.Type) input.ReadEnum();
+            break;
+          }
+          case 34: {
+            Format = input.ReadString();
+            break;
+          }
+          case 40: {
+            Required = input.ReadBool();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+    #region Nested types
+    /// <summary>Container for nested types declared in the HeaderParameter message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static partial class Types {
+      /// <summary>
+      /// `Type` is a a supported HTTP header type.
+      /// See https://swagger.io/specification/v2/#parameterType.
+      /// </summary>
+      public enum Type {
+        [pbr::OriginalName("UNKNOWN")] Unknown = 0,
+        [pbr::OriginalName("STRING")] String = 1,
+        [pbr::OriginalName("NUMBER")] Number = 2,
+        [pbr::OriginalName("INTEGER")] Integer = 3,
+        [pbr::OriginalName("BOOLEAN")] Boolean = 4,
+      }
+
+    }
+    #endregion
 
   }
 
@@ -1496,7 +2172,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[2]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[4]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1855,7 +2531,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[3]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[5]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1957,6 +2633,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
         = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 42);
     private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
@@ -2085,9 +2766,9 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         Schema.MergeFrom(other.Schema);
       }
-      headers_.Add(other.headers_);
-      examples_.Add(other.examples_);
-      extensions_.Add(other.extensions_);
+      headers_.MergeFrom(other.headers_);
+      examples_.MergeFrom(other.examples_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -2190,7 +2871,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///      };
   ///      license: {
   ///        name: "BSD 3-Clause License";
-  ///        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+  ///        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
   ///      };
   ///    };
   ///    ...
@@ -2210,7 +2891,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[4]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[6]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2343,6 +3024,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
         = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 58);
     private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
@@ -2528,7 +3214,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other.Version.Length != 0) {
         Version = other.Version;
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -2668,7 +3354,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[5]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2940,7 +3626,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///      ...
   ///      license: {
   ///        name: "BSD 3-Clause License";
-  ///        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+  ///        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
   ///      };
   ///      ...
   ///    };
@@ -2961,7 +3647,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[6]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3210,7 +3896,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[7]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[9]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3449,7 +4135,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[8]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3854,7 +4540,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[9]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[11]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4249,6 +4935,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
         = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 386);
     private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
@@ -4695,7 +5386,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         FieldConfiguration.MergeFrom(other.FieldConfiguration);
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -5186,7 +5877,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[10]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[12]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5206,8 +5897,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Tag(Tag other) : this() {
+      name_ = other.name_;
       description_ = other.description_;
       externalDocs_ = other.externalDocs_ != null ? other.externalDocs_.Clone() : null;
+      extensions_ = other.extensions_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -5215,6 +5908,23 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Tag Clone() {
       return new Tag(this);
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 1;
+    private string name_ = "";
+    /// <summary>
+    /// The name of the tag. Use it to allow override of the name of a
+    /// global Tag object, then use that name to reference the tag throughout the
+    /// OpenAPI file.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
     }
 
     /// <summary>Field number for the "description" field.</summary>
@@ -5248,6 +5958,22 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       }
     }
 
+    /// <summary>Field number for the "extensions" field.</summary>
+    public const int ExtensionsFieldNumber = 4;
+    private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
+        = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 34);
+    private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
+      get { return extensions_; }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -5263,8 +5989,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (ReferenceEquals(other, this)) {
         return true;
       }
+      if (Name != other.Name) return false;
       if (Description != other.Description) return false;
       if (!object.Equals(ExternalDocs, other.ExternalDocs)) return false;
+      if (!Extensions.Equals(other.Extensions)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -5272,8 +6000,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
       if (Description.Length != 0) hash ^= Description.GetHashCode();
       if (externalDocs_ != null) hash ^= ExternalDocs.GetHashCode();
+      hash ^= Extensions.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -5292,6 +6022,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
       if (Description.Length != 0) {
         output.WriteRawTag(18);
         output.WriteString(Description);
@@ -5300,6 +6034,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         output.WriteRawTag(26);
         output.WriteMessage(ExternalDocs);
       }
+      extensions_.WriteTo(output, _map_extensions_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -5310,6 +6045,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
       if (Description.Length != 0) {
         output.WriteRawTag(18);
         output.WriteString(Description);
@@ -5318,6 +6057,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         output.WriteRawTag(26);
         output.WriteMessage(ExternalDocs);
       }
+      extensions_.WriteTo(ref output, _map_extensions_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -5328,12 +6068,16 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
       if (Description.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Description);
       }
       if (externalDocs_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ExternalDocs);
       }
+      size += extensions_.CalculateSize(_map_extensions_codec);
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -5346,6 +6090,9 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
       if (other.Description.Length != 0) {
         Description = other.Description;
       }
@@ -5355,6 +6102,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         ExternalDocs.MergeFrom(other.ExternalDocs);
       }
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -5370,6 +6118,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
           case 18: {
             Description = input.ReadString();
             break;
@@ -5379,6 +6131,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
               ExternalDocs = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.ExternalDocumentation();
             }
             input.ReadMessage(ExternalDocs);
+            break;
+          }
+          case 34: {
+            extensions_.AddEntriesFrom(input, _map_extensions_codec);
             break;
           }
         }
@@ -5396,6 +6152,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
           case 18: {
             Description = input.ReadString();
             break;
@@ -5405,6 +6165,10 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
               ExternalDocs = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.ExternalDocumentation();
             }
             input.ReadMessage(ExternalDocs);
+            break;
+          }
+          case 34: {
+            extensions_.AddEntriesFrom(ref input, _map_extensions_codec);
             break;
           }
         }
@@ -5438,7 +6202,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[11]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[13]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5560,7 +6324,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
-      security_.Add(other.security_);
+      security_.MergeFrom(other.security_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -5631,7 +6395,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[12]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[14]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5805,6 +6569,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_extensions_codec
         = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec(pb::FieldCodec.ForString(10, ""), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.WellKnownTypes.Value.Parser), 74);
     private readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> extensions_ = new pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>();
+    /// <summary>
+    /// Custom properties that start with "x-" such as "x-foo" used to describe
+    /// extra functionality that is not covered by the standard OpenAPI Specification.
+    /// See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value> Extensions {
@@ -6019,7 +6788,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         Scopes.MergeFrom(other.Scopes);
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -6202,7 +6971,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[13]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6326,7 +7095,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
-      securityRequirement_.Add(other.securityRequirement_);
+      securityRequirement_.MergeFrom(other.securityRequirement_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -6584,7 +7353,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[14]; }
+      get { return global::Grpc.Gateway.ProtocGenOpenapiv2.Options.Openapiv2Reflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6706,7 +7475,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
-      scope_.Add(other.scope_);
+      scope_.MergeFrom(other.scope_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 

--- a/src/Sdk/SvcGrpc.cs
+++ b/src/Sdk/SvcGrpc.cs
@@ -6,7 +6,7 @@
 // Copyright 2021-2023 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 //
-#pragma warning disable 0414, 1591
+#pragma warning disable 0414, 1591, 8981
 #region Designer generated code
 
 using grpc = global::Grpc.Core;


### PR DESCRIPTION
- Adds support for the user-defined outputs (cerbos/cerbos#1594)
  - resolves #78 
- Adds support for `IncludeMeta` field
- Adds `resource`, `meta`, `outputs` fields of the `CheckResourceResponse`.