### PR TITLE
enhancement: Metadata (headers) support

### DIFF
--- a/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosClientTest.cs
+++ b/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosClientTest.cs
@@ -21,6 +21,8 @@ namespace Cerbos.Sdk.UnitTests
         private const string Tag = "dev";
         private const string PathToPolicies = "./../../../res/policies";
         private const string PathToConfig = "./../../../res/config";
+        private readonly Grpc.Core.Metadata _metadata = new() { { "wibble", "wobble" } };
+
         private IContainer? _container;
         
         private CerbosClient? _client;
@@ -45,8 +47,8 @@ namespace Cerbos.Sdk.UnitTests
 
             Task.Run(async () => await _container.StartAsync()).Wait();
             Thread.Sleep(3000);
-            _client = CerbosClientBuilder.ForTarget("http://127.0.0.1:3593").WithPlaintext().Build();
-            _clientPlayground = CerbosClientBuilder.ForTarget(PlaygroundHost).WithPlaygroundInstance(PlaygroundInstanceId).Build();
+            _client = CerbosClientBuilder.ForTarget("http://127.0.0.1:3593").WithMetadata(_metadata).WithPlaintext().Build();
+            _clientPlayground = CerbosClientBuilder.ForTarget(PlaygroundHost).WithMetadata(_metadata).WithPlaygroundInstance(PlaygroundInstanceId).Build();
         }
 
         [OneTimeTearDown]
@@ -81,7 +83,7 @@ namespace Cerbos.Sdk.UnitTests
                 )
                 .WithIncludeMeta(true);
             
-            var have = _client.CheckResources(request).Find("XX125");
+            var have = _client.CheckResources(request, _metadata).Find("XX125");
             Assert.That(have.IsAllowed("view:public"), Is.True);
             Assert.That(have.IsAllowed("approve"), Is.False);
             
@@ -126,7 +128,7 @@ namespace Cerbos.Sdk.UnitTests
                         .WithActions("defer")
                 );
             
-            var have = _client.CheckResources(request).Find("XX125");
+            var have = _client.CheckResources(request, _metadata).Find("XX125");
             Assert.That(have.IsAllowed("defer"), Is.True);
         }
         
@@ -175,7 +177,7 @@ namespace Cerbos.Sdk.UnitTests
                 );
 
 
-            var have = _client.CheckResources(request);
+            var have = _client.CheckResources(request, _metadata);
             var resourcexx125 = have.Find("XX125");
             Assert.That(resourcexx125.IsAllowed("view:public"), Is.True);
             Assert.That(resourcexx125.IsAllowed("defer"), Is.True);
@@ -213,7 +215,7 @@ namespace Cerbos.Sdk.UnitTests
                 .WithAction("approve");
 
             
-            var have = _client.PlanResources(request);
+            var have = _client.PlanResources(request, _metadata);
             Assert.That(have.Action, Is.EqualTo("approve"));
             Assert.That(have.PolicyVersion, Is.EqualTo("20210210"));
             Assert.That(have.ResourceKind, Is.EqualTo("leave_request"));
@@ -260,7 +262,7 @@ namespace Cerbos.Sdk.UnitTests
                 )
                 .WithAction("approve");
             
-            var have = _client.PlanResources(request);
+            var have = _client.PlanResources(request, _metadata);
             Assert.That(have.Action, Is.EqualTo("approve"));
             Assert.That(have.PolicyVersion, Is.EqualTo("20210210"));
             Assert.That(have.ResourceKind, Is.EqualTo("leave_request"));
@@ -302,7 +304,7 @@ namespace Cerbos.Sdk.UnitTests
                         .WithActions("approve", "delete")
                 );
 
-            var have = _clientPlayground.CheckResources(request).Find("XX125");
+            var have = _clientPlayground.CheckResources(request, _metadata).Find("XX125");
             Assert.That(have.IsAllowed("approve"), Is.True);
             Assert.That(have.IsAllowed("delete"), Is.True);
         }
@@ -333,7 +335,7 @@ namespace Cerbos.Sdk.UnitTests
                         .WithActions("approve", "view:public")
                 );
 
-            var have = (await _client.CheckResourcesAsync(request)).Find("XX125");
+            var have = (await _client.CheckResourcesAsync(request, _metadata)).Find("XX125");
             Assert.That(have.IsAllowed("view:public"), Is.True);
             Assert.That(have.IsAllowed("approve"), Is.False);
             

--- a/src/Sdk/Cerbos/Sdk/Builder/CerbosClientBuilder.cs
+++ b/src/Sdk/Cerbos/Sdk/Builder/CerbosClientBuilder.cs
@@ -20,6 +20,7 @@ namespace Cerbos.Sdk.Builder
         private StreamReader TlsCertificate { get; set; }
         private StreamReader TlsKey { get; set; }
         private GrpcChannelOptions GrpcChannelOptions { get; set; }
+        private Metadata Metadata { get; set; }
 
         private CerbosClientBuilder(string target) {
             Target = target;
@@ -28,6 +29,12 @@ namespace Cerbos.Sdk.Builder
         public static CerbosClientBuilder ForTarget(string target)
         {
             return new CerbosClientBuilder(target);
+        }
+
+        public CerbosClientBuilder WithMetadata(Metadata headers)
+        {
+            Metadata = headers;
+            return this;
         }
 
         public CerbosClientBuilder WithPlaintext() {
@@ -87,6 +94,14 @@ namespace Cerbos.Sdk.Builder
                 callCredentials = CallCredentials.FromInterceptor((context, metadata) =>
                 {
                     metadata.Add(PlaygroundInstanceHeader, PlaygroundInstanceId.Trim());
+                    if (Metadata != null)
+                    {
+                        foreach (var m in Metadata)
+                        {
+                            metadata.Add(m);
+                        }
+                    }
+
                     return Task.CompletedTask;
                 });
             }

--- a/src/Sdk/Cerbos/Sdk/CerbosClient.cs
+++ b/src/Sdk/Cerbos/Sdk/CerbosClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Cerbos.Sdk.Response;
+using Grpc.Core;
 
 namespace Cerbos.Sdk
 {
@@ -22,11 +23,11 @@ namespace Cerbos.Sdk
         /// <summary>
         /// Send a request consisting of a principal, resource(s) & action(s) to see if the principal is authorized to do the action(s) on the resource(s).
         /// </summary>
-        public CheckResourcesResponse CheckResources(Builder.CheckResourcesRequest request)
+        public CheckResourcesResponse CheckResources(Builder.CheckResourcesRequest request, Metadata headers = null)
         {
             try
             {
-                return new CheckResourcesResponse(CerbosServiceClient.CheckResources(request.ToCheckResourcesRequest()));
+                return new CheckResourcesResponse(CerbosServiceClient.CheckResources(request.ToCheckResourcesRequest(), headers));
             }
             catch (Exception e)
             {
@@ -37,12 +38,12 @@ namespace Cerbos.Sdk
         /// <summary>
         /// Send an async request consisting of a principal, resource(s) & action(s) to see if the principal is authorized to do the action(s) on the resource(s).
         /// </summary>
-        public Task<CheckResourcesResponse> CheckResourcesAsync(Builder.CheckResourcesRequest request)
+        public Task<CheckResourcesResponse> CheckResourcesAsync(Builder.CheckResourcesRequest request, Metadata headers = null)
         {
             try
             {
                 return CerbosServiceClient
-                    .CheckResourcesAsync(request.ToCheckResourcesRequest())
+                    .CheckResourcesAsync(request.ToCheckResourcesRequest(), headers)
                     .ResponseAsync
                     .ContinueWith(
                         r => new CheckResourcesResponse(r.Result)
@@ -57,11 +58,11 @@ namespace Cerbos.Sdk
         /// <summary>
         /// Obtain a query plan for performing the given action on the given resource kind.
         /// </summary>
-        public PlanResourcesResponse PlanResources(Builder.PlanResourcesRequest request)
+        public PlanResourcesResponse PlanResources(Builder.PlanResourcesRequest request, Metadata headers = null)
         {
             try
             {
-                return new PlanResourcesResponse(CerbosServiceClient.PlanResources(request.ToPlanResourcesRequest()));
+                return new PlanResourcesResponse(CerbosServiceClient.PlanResources(request.ToPlanResourcesRequest(), headers));
             }
             catch (Exception e)
             {
@@ -72,12 +73,12 @@ namespace Cerbos.Sdk
         /// <summary>
         /// Obtain a query plan for performing the given action on the given resource kind.
         /// </summary>
-        public Task<PlanResourcesResponse> PlanResourcesAsync(Builder.PlanResourcesRequest request)
+        public Task<PlanResourcesResponse> PlanResourcesAsync(Builder.PlanResourcesRequest request, Metadata headers = null)
         {
             try
             {
                 return CerbosServiceClient
-                    .PlanResourcesAsync(request.ToPlanResourcesRequest())
+                    .PlanResourcesAsync(request.ToPlanResourcesRequest(), headers)
                     .ResponseAsync
                     .ContinueWith(
                         r => new PlanResourcesResponse(r.Result)

--- a/src/Sdk/Cerbos/Sdk/CerbosClient.cs
+++ b/src/Sdk/Cerbos/Sdk/CerbosClient.cs
@@ -14,10 +14,12 @@ namespace Cerbos.Sdk
     public sealed class CerbosClient
     {
         private Api.V1.Svc.CerbosService.CerbosServiceClient CerbosServiceClient { get; }
-
-        public CerbosClient(Api.V1.Svc.CerbosService.CerbosServiceClient cerbosServiceClient)
+        private readonly Metadata _metadata;
+        
+        public CerbosClient(Api.V1.Svc.CerbosService.CerbosServiceClient cerbosServiceClient, Metadata metadata = null)
         {
             CerbosServiceClient = cerbosServiceClient;
+            _metadata = metadata;
         }
 
         /// <summary>
@@ -27,7 +29,7 @@ namespace Cerbos.Sdk
         {
             try
             {
-                return new CheckResourcesResponse(CerbosServiceClient.CheckResources(request.ToCheckResourcesRequest(), headers));
+                return new CheckResourcesResponse(CerbosServiceClient.CheckResources(request.ToCheckResourcesRequest(), Utility.Metadata.Merge(_metadata, headers)));
             }
             catch (Exception e)
             {
@@ -43,7 +45,7 @@ namespace Cerbos.Sdk
             try
             {
                 return CerbosServiceClient
-                    .CheckResourcesAsync(request.ToCheckResourcesRequest(), headers)
+                    .CheckResourcesAsync(request.ToCheckResourcesRequest(), Utility.Metadata.Merge(_metadata, headers))
                     .ResponseAsync
                     .ContinueWith(
                         r => new CheckResourcesResponse(r.Result)
@@ -62,7 +64,7 @@ namespace Cerbos.Sdk
         {
             try
             {
-                return new PlanResourcesResponse(CerbosServiceClient.PlanResources(request.ToPlanResourcesRequest(), headers));
+                return new PlanResourcesResponse(CerbosServiceClient.PlanResources(request.ToPlanResourcesRequest(), Utility.Metadata.Merge(_metadata, headers)));
             }
             catch (Exception e)
             {
@@ -78,7 +80,7 @@ namespace Cerbos.Sdk
             try
             {
                 return CerbosServiceClient
-                    .PlanResourcesAsync(request.ToPlanResourcesRequest(), headers)
+                    .PlanResourcesAsync(request.ToPlanResourcesRequest(), Utility.Metadata.Merge(_metadata, headers))
                     .ResponseAsync
                     .ContinueWith(
                         r => new PlanResourcesResponse(r.Result)

--- a/src/Sdk/Cerbos/Sdk/Utility/Metadata.cs
+++ b/src/Sdk/Cerbos/Sdk/Utility/Metadata.cs
@@ -1,0 +1,36 @@
+namespace Cerbos.Sdk.Utility
+{
+    public static class Metadata
+    {
+        public static Grpc.Core.Metadata Merge(Grpc.Core.Metadata first, Grpc.Core.Metadata second)
+        {
+            if (first == null && second == null)
+            {
+                return null;
+            }
+
+            if (first != null && second == null)
+            {
+                return first;
+            }
+
+            if (first == null)
+            {
+                return second;
+            }
+
+            Grpc.Core.Metadata combined = new Grpc.Core.Metadata();
+            foreach (var m in first)
+            {
+                combined.Add(m);
+            }
+            
+            foreach (var m in second)
+            {
+                combined.Add(m);
+            }
+            
+            return combined;
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Added gRPC Metadata support
- Simplified the internal client-building logic

### Example

When metadata (`{"wibble": "wobble"}`) is provided during both client initialization and CheckResources call, the cerbos audit logs show;
```
{
  "log.logger":"cerbos.audit",
  "log.kind":"access",
  "timestamp":"2023-12-13T17:26:56.614190Z",
  "callId":"01HHJ3F8B657J3PB3S6P21YY3X",
  "peer":{
    "address":"127.0.0.1:50993",
    "userAgent":"grpc-dotnet/2.59.0 (.NET 6.0.5; CLR 6.0.5; net6.0; osx; x64)"
  },
  "metadata":{
    "wibble":{
      "values":[
        "wobble, wobble"
      ]
    }
  },
  "method":"/cerbos.svc.v1.CerbosService/CheckResources"
}
```