### PR TITLE
enhancement!: Add ICerbosClient interface for testing

### DIFF
--- a/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosClientTest.cs
+++ b/src/Sdk.UnitTests/Cerbos/Sdk/UnitTests/CerbosClientTest.cs
@@ -25,8 +25,8 @@ namespace Cerbos.Sdk.UnitTests
 
         private IContainer? _container;
         
-        private CerbosClient? _client;
-        private CerbosClient? _clientPlayground;
+        private ICerbosClient? _client;
+        private ICerbosClient? _clientPlayground;
 
         private readonly string _jwt =
             "eyJhbGciOiJFUzM4NCIsImtpZCI6IjE5TGZaYXRFZGc4M1lOYzVyMjNndU1KcXJuND0iLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsiY2VyYm9zLWp3dC10ZXN0cyJdLCJjdXN0b21BcnJheSI6WyJBIiwiQiIsIkMiXSwiY3VzdG9tSW50Ijo0MiwiY3VzdG9tTWFwIjp7IkEiOiJBQSIsIkIiOiJCQiIsIkMiOiJDQyJ9LCJjdXN0b21TdHJpbmciOiJmb29iYXIiLCJleHAiOjE5NTAyNzc5MjYsImlzcyI6ImNlcmJvcy10ZXN0LXN1aXRlIn0._nCHIsuFI3wczeuUv_xjSwaVnIQUdYA9sGf_jVsrsDWloLs3iPWDaA1bXpuIUJVsi8-G6qqdrPI0cOBxEocg1NCm8fyD9T_3hsZV0fYWon_Je6Kl93a3JIW3S6kbvjsL";

--- a/src/Sdk/Cerbos/Sdk/Builder/CerbosClientBuilder.cs
+++ b/src/Sdk/Cerbos/Sdk/Builder/CerbosClientBuilder.cs
@@ -69,7 +69,7 @@ namespace Cerbos.Sdk.Builder
             return this;
         }
 
-        public CerbosClient Build()
+        public ICerbosClient Build()
         {
             if (string.IsNullOrEmpty(Target))
             {

--- a/src/Sdk/Cerbos/Sdk/CerbosClient.cs
+++ b/src/Sdk/Cerbos/Sdk/CerbosClient.cs
@@ -11,7 +11,7 @@ namespace Cerbos.Sdk
     /// <summary>
     /// CerbosClient provides a client implementation that communicates with the PDP.
     /// </summary>
-    public sealed class CerbosClient
+    public sealed class CerbosClient: ICerbosClient
     {
         private Api.V1.Svc.CerbosService.CerbosServiceClient CerbosServiceClient { get; }
         private readonly Metadata _metadata;

--- a/src/Sdk/Cerbos/Sdk/ICerbosClient.cs
+++ b/src/Sdk/Cerbos/Sdk/ICerbosClient.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using Cerbos.Sdk.Response;
+using Grpc.Core;
+
+namespace Cerbos.Sdk
+{
+    public interface ICerbosClient
+    {
+        CheckResourcesResponse CheckResources(Builder.CheckResourcesRequest request, Metadata headers = null);
+        Task<CheckResourcesResponse> CheckResourcesAsync(Builder.CheckResourcesRequest request, Metadata headers = null);
+        PlanResourcesResponse PlanResources(Builder.PlanResourcesRequest request, Metadata headers = null);
+        Task<PlanResourcesResponse> PlanResourcesAsync(Builder.PlanResourcesRequest request, Metadata headers = null);
+    }
+}


### PR DESCRIPTION
This PR adds `ICerbosClient` interface and modifies `Build` method of the `CerbosClientBuilder` to return `ICerbosClient` instead. Resolves #143.