### PR TITLE
Bump protovalidate to version 1.0.1

### DIFF
--- a/src/Sdk/sdk.csproj
+++ b/src/Sdk/sdk.csproj
@@ -24,6 +24,6 @@
         <PackageReference Include="Grpc" Version="2.46.6" />
         <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
         <PackageReference Include="Polly" Version="8.6.6" />
-        <PackageReference Include="ProtoValidate" Version="1.0.0" />
+        <PackageReference Include="ProtoValidate" Version="1.0.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
#### Description

Bump protovalidate to version 1.0.1 which fixes CVE-2025-55247 (which is getting triggered on trivvy and other scanner).

Fixes #246

#### Checklist 

<!-- See https://github.com/cerbos/.github/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [X] PR is linked to the corresponding issue
- [X] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
